### PR TITLE
introduce chunk processor. similar to queue processor, but processes …

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,3 +335,36 @@ pendingNotifications.push("test!")
 ```
 
 Returns **IDisposer** stops the processor
+
+## chunkProcessor
+
+`chunkProcessor` takes an observable array, observes it and calls `processor`
+once for a chunk of items added to the observable array, optionally deboucing the action.
+The maximum chunk size can be limited by number.
+This allows both, splitting larger into smaller chunks or (when debounced) combining smaller
+chunks and/or single items into reasonable chunks of work.
+ 
+
+**Parameters**
+
+-   `observableArray` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;T>** observable array instance to track
+-   `processor`  
+-   `debounce` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** optional debounce time in ms. With debounce 0 the processor will run synchronously (optional, default `0`)
+-   `maxChunkSize` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** optional maximal length of a chunk. With maxChunkSize 0 the processor will receive the full array at once (optional, default `0`)
+
+**Examples**
+
+```javascript
+const trackedActions = observable([])
+const stop = chunkProcessor(trackedActions, chunkOfMax10Items => {
+  sendTrackedActionsToServer(chunkOfMax10Items);
+}, 100, 10)
+
+// usage:
+trackedActions.push("scrolled")
+trackedActions.push("hoveredButton")
+// when both pushes happen within 100ms, there will be only one call to server
+// no more than 10 items will be send within one call. Otherwise more calls will be done (immediately).
+```
+
+Returns **IDisposer** stops the processor

--- a/src/chunk-processor.ts
+++ b/src/chunk-processor.ts
@@ -1,0 +1,50 @@
+import {isAction, autorun, autorunAsync, action, isObservableArray, runInAction} from "mobx";
+import {IDisposer} from "./utils";
+
+/**
+ * `chunkProcessor` takes an observable array, observes it and calls `processor`
+ * once for a chunk of items added to the observable array, optionally deboucing the action.
+ * The maximum chunk size can be limited by number.
+ * This allows both, splitting larger into smaller chunks or (when debounced) combining smaller
+ * chunks and/or single items into reasonable chunks of work.
+ *
+ * @example
+ * const trackedActions = observable([])
+ * const stop = chunkProcessor(trackedActions, chunkOfMax10Items => {
+ *   sendTrackedActionsToServer(chunkOfMax10Items);
+ * }, 100, 10)
+ *
+ * // usage:
+ * trackedActions.push("scrolled")
+ * trackedActions.push("hoveredButton")
+ * // when both pushes happen within 100ms, there will be only one call to server
+ * 
+ * @param {T[]} observableArray observable array instance to track
+ * @param {(item: T[]) => void} processor action to call per item
+ * @param {number} [debounce=0] optional debounce time in ms. With debounce 0 the processor will run synchronously
+ * @param {number} [maxChunkSize=0] optionally do not call on full array but smaller chunks. With 0 it will process the full array.
+ * @returns {IDisposer} stops the processor
+ */
+export function chunkProcessor<T>(observableArray: T[], processor: (item: T[]) => void, debounce = 0, maxChunkSize=0): IDisposer {
+    if (!isObservableArray(observableArray))
+        throw new Error("Expected observable array as first argument");
+    if (!isAction(processor))
+        processor = action("chunkProcessor", processor);
+
+    const runner = () => {
+
+        while(observableArray.length > 0) {
+            let chunkSize = maxChunkSize === 0 ? observableArray.length : Math.min(observableArray.length, maxChunkSize);
+            // construct a final set
+            const items = observableArray.slice(0, chunkSize);
+            // clear the slice for next iteration
+            runInAction(() => observableArray.splice(0, chunkSize));
+            // fire processor
+            processor(items);
+        }
+    };
+    if (debounce > 0)
+        return autorunAsync(runner, debounce);
+    else
+        return autorun(runner);
+}

--- a/src/mobx-utils.ts
+++ b/src/mobx-utils.ts
@@ -5,4 +5,5 @@ export * from "./create-view-model";
 export * from "./guarded-when";
 export * from "./keep-alive";
 export * from "./queue-processor";
+export * from "./chunk-processor";
 export * from "./utils";

--- a/test/chunk-processor.js
+++ b/test/chunk-processor.js
@@ -1,0 +1,133 @@
+"use strict";
+
+const utils = require("../");
+const mobx = require("mobx");
+const test = require("tape");
+
+mobx.useStrict(true);
+
+test("sync processor should work with max", t => {
+    const q = mobx.observable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    const res = [];
+
+    const stop = utils.chunkProcessor(q, v => res.push(v),0,3)
+
+    t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10]])
+    t.equal(q.length, 0)
+
+    mobx.runInAction(() => q.push(1,2,3,4,5))
+    t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10], [1,2,3], [4,5]])
+    t.equal(q.length, 0)
+
+    mobx.runInAction(() => q.push(3))
+    t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10], [1,2,3], [4,5], [3]])
+    t.equal(q.length, 0)
+
+    mobx.runInAction(() => q.push(8,9))
+    t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10], [1,2,3], [4,5], [3], [8,9]])
+    t.equal(q.length, 0)
+
+    mobx.runInAction(() => {
+        q.unshift(6, 7)
+        t.equal(q.length, 2)
+        t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10], [1,2,3], [4,5], [3], [8,9]])
+    })
+    t.equal(q.length, 0)
+    t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10], [1,2,3], [4,5], [3], [8,9], [6, 7]])
+
+    stop()
+    mobx.runInAction(() => q.push(42))
+    t.equal(q.length, 1)
+    t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10], [1,2,3], [4,5], [3], [8,9], [6, 7]])
+
+    t.end();
+})
+
+test("sync processor should work with default max", t => {
+    const q = mobx.observable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    const res = [];
+
+    const stop = utils.chunkProcessor(q, v => res.push(v))
+
+    t.deepEqual(res, [[1,2,3,4,5,6,7,8,9,10]])
+    t.equal(q.length, 0)
+
+    mobx.runInAction(() => q.push(1,2,3,4,5))
+    t.deepEqual(res, [[1,2,3,4,5,6,7,8,9,10], [1,2,3,4,5]])
+    t.equal(q.length, 0)
+
+    t.end();
+})
+
+test("async processor should work", t => {
+    const q = mobx.observable([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    const res = [];
+
+    const stop = utils.chunkProcessor(q, v => res.push(v), 10, 3)
+
+    t.equal(res.length, 0)
+    t.equal(q.length, 10)
+
+    setTimeout(() => {
+        t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10]])
+        t.equal(q.length, 0)
+
+        mobx.runInAction(() => q.push(3))
+        t.equal(q.length, 1)
+        t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10]])
+
+        setTimeout(() => {
+            t.equal(q.length, 0)
+            t.deepEqual(res, [[1,2,3], [4,5,6], [7,8,9], [10], [3]])
+
+            stop()
+            t.end()
+        }, 50)
+    }, 50)
+
+})
+
+
+test("async processor should combine smaller chunks to max size", t => {
+    const q = mobx.observable([1, 2])
+    const res = [];
+
+    const stop = utils.chunkProcessor(q, v => res.push(v), 10, 3)
+
+    t.equal(res.length, 0)
+    t.equal(q.length, 2)
+    mobx.runInAction(() =>q.push(3));
+    mobx.runInAction(() =>q.push(4));
+    mobx.runInAction(() =>q.push(5));
+    mobx.runInAction(() =>q.push(6));
+    mobx.runInAction(() =>q.push(7));
+
+    setTimeout(() => {
+        t.deepEqual(res, [[1,2,3], [4,5,6], [7]])
+        t.equal(q.length, 0)
+
+        mobx.runInAction(() => q.push(8,9))
+        setTimeout(() => {
+            mobx.runInAction(() => q.push(10,11))
+            t.equal(q.length, 4)
+            t.deepEqual(res, [[1,2,3], [4,5,6], [7]])
+        }, 2);
+        setTimeout(() => {
+            mobx.runInAction(() => q.push(12,13))
+            t.equal(q.length, 6)
+            t.deepEqual(res, [[1,2,3], [4,5,6], [7]])
+        }, 4);
+        
+        t.equal(q.length, 2)
+        t.deepEqual(res, [[1,2,3], [4,5,6], [7]])
+
+        setTimeout(() => {
+            t.equal(q.length, 0)
+            t.deepEqual(res, [[1,2,3], [4,5,6], [7], [8,9,10], [11,12,13]])
+
+            stop()
+            t.end()
+        }, 50)
+    }, 50)
+
+})


### PR DESCRIPTION
introduce chunk processor.
similar to queue processor, but processes chunks of the array instead of single items


This extension solves a use case for me which seems quite generic, so I decided to contribute it here.

I thought about several extensions on top, like
* minimum chunk size (and timeout to process anyway even if minimum is not reached)
* throttling between processing chunks
* specify max chunk size as function to calculate a maximum chunk size (e.g. combined length of string items etc)

... but the current state is exactly what I needed so I stopped here.
