### PR TITLE
add reset feature for lazyObservable

### DIFF
--- a/src/lazy-observable.ts
+++ b/src/lazy-observable.ts
@@ -31,7 +31,8 @@ import {observable, action} from "mobx";
  * @param {any} [modifier=IDENTITY] optional mobx modifier that determines the the comparison and recursion strategy of the observable, for example `asFlat` or `asStructure`
  * @returns {{
  *     current(): T,
- *     refresh(): T
+ *     refresh(): T,
+ *     reset(): T
  * }}
  */
 
@@ -41,7 +42,8 @@ export function lazyObservable<T>(
     modifier = IDENTITY
 ): {
     current(): T,
-    refresh(): T
+    refresh(): T,
+    reset(): T
 } {
     let started = false;
     const value = observable(modifier(initialValue));
@@ -54,11 +56,18 @@ export function lazyObservable<T>(
         }
         return value.get();
     };
+    let resetFnc = action("lazyObservable-reset", () => {
+      value.set(initialValue);
+      return value.get();
+    });
     return {
         current: currentFnc,
         refresh: () => {
             started = false;
             return currentFnc();
+        },
+        reset: () => {
+            return resetFnc();
         }
     };
 }

--- a/test/lazy-observable.js
+++ b/test/lazy-observable.js
@@ -65,3 +65,27 @@ test('lazy observable refresh', t => {
     t.end();
   }, 200);
 });
+
+test('lazy observable reset', t => {
+  const lo = utils.lazyObservable(
+    sink => new Promise(resolve => {
+      resolve(2);
+    }).then(value => {
+      sink(value);
+    }),
+    1
+  );
+
+  lo.current();
+
+  setTimeout(() => {
+    t.equal(lo.current(), 2);
+  }, 50);
+
+  setTimeout(() => lo.reset(), 150);
+
+  setTimeout(() => {
+    t.equal(lo.current(), 1);
+    t.end();
+  }, 200);
+});


### PR DESCRIPTION
In my case, I have a Tab component with two tabs (**Opening issues** and **Closed issues**). 

In each tab, we have a list of issues. Two tabs use only one lazyObservable instance. This instance fetch data from server base on the **state** flag of issue.

When user changes between tabs, we reset the lazyObservable instance to initial state. Then **current()** will fetch data again.
