### PR TITLE
fix mobx3 deprecation warnings in npm run test

### DIFF
--- a/src/create-view-model.ts
+++ b/src/create-view-model.ts
@@ -1,4 +1,4 @@
-import {action, ObservableMap, asMap, isObservableObject, isObservableArray, isObservableMap, computed} from "mobx";
+import {action, ObservableMap, observable, isObservableObject, isObservableArray, isObservableMap, computed} from "mobx";
 import {invariant} from "./utils";
 
 export interface IViewModel<T> {
@@ -12,7 +12,7 @@ export interface IViewModel<T> {
 const RESERVED_NAMES = ["model", "reset", "submit", "isDirty", "isPropertyDirty"];
 
 class ViewModel<T> implements IViewModel<T> {
-    localValues: ObservableMap<any> = asMap({});
+    localValues: ObservableMap<any> = observable.map({});
 
     @computed get isDirty() {
         return this.localValues.size > 0;

--- a/test/observable-stream.js
+++ b/test/observable-stream.js
@@ -23,7 +23,7 @@ test("to observable", t => {
 
   user.firstName = "John"
 
-  mobx.transaction(() => {
+  mobx.runInAction(() => {
     user.firstName = "Jane";
     user.lastName = "Jack";
   })


### PR DESCRIPTION
'from Promise' throws a deprecation warning as well, but that one is not related to mobx3 so it wasn't updated.