### PR TITLE
Fix fromStream to handle already completed streams

### DIFF
--- a/src/observable-stream.ts
+++ b/src/observable-stream.ts
@@ -76,7 +76,9 @@ class StreamListener<T> implements IStreamObserver<T> {
     }
 
     dispose() {
-        this.subscription.unsubscribe();
+        if (this.subscription) {
+            this.subscription.unsubscribe();
+        }
     }
 
     @action next(value: T) {
@@ -84,7 +86,6 @@ class StreamListener<T> implements IStreamObserver<T> {
     }
 
     @action complete() {
-        this.subscription.unsubscribe();
         this.dispose();
     }
 


### PR DESCRIPTION
In the implementation of `StreamListener` for `fromStream`, the `complete()` handler (for a completed observable stream) [calls `this.subscription.unsubscribe()`][unsub].

Unfortunately, `this.subscription` is initialized with the line `this.subscription = observable.subscribe(this)` [in the constructor][sub].

This requires first evaluating `observable.subscribe(this)`, which calls the `complete()` handler if an already-completed observable was passed to it. As such, for already-completed observables, `fromStream` tries to call `.unsubscribe()` on `this.subscription` before it is initialized.

This fix simply doesn't try to unsubscribe if the complete handler fires before the subscription field has been initialized (is there any value in unsubscribing from a completed observable?)

Minimal demonstration of the problem (notice the TypeError): https://www.webpackbin.com/bins/-Kh-S16Cm9XIGUJ6Ou0k and the fixed version: https://www.webpackbin.com/bins/-Kh-RiOddodXZ0h7B0rY

[unsub]: https://github.com/mobxjs/mobx-utils/blob/89f3da595cf1c22697ba701d101e6ad31c001f64/src/observable-stream.ts#L87
[sub]: https://github.com/mobxjs/mobx-utils/blob/89f3da595cf1c22697ba701d101e6ad31c001f64/src/observable-stream.ts#L74