### PR TITLE
[createViewModel] Fix context for methods.

### DIFF
--- a/src/create-view-model.ts
+++ b/src/create-view-model.ts
@@ -26,13 +26,13 @@ class ViewModel<T> implements IViewModel<T> {
                 enumerable: true,
                 configurable: true,
                 get: () => {
-                    if (isPropertyDirty(key))
+                    if (this.isPropertyDirty(key))
                         return this.localValues.get(key);
                     else
                         return (this.model as any)[key];
                 },
                 set: action((value: any) => {
-                    if (isPropertyDirty(key) || value !== (this.model as any)[key]) {
+                    if (this.isPropertyDirty(key) || value !== (this.model as any)[key]) {
                         this.localValues.set(key, value);
                     }
                 })

--- a/src/create-view-model.ts
+++ b/src/create-view-model.ts
@@ -26,13 +26,13 @@ class ViewModel<T> implements IViewModel<T> {
                 enumerable: true,
                 configurable: true,
                 get: () => {
-                    if (this.isPropertyDirty(key))
+                    if (this.localValues.has(key))
                         return this.localValues.get(key);
                     else
                         return (this.model as any)[key];
                 },
                 set: action((value: any) => {
-                    if (this.isPropertyDirty(key) || value !== (this.model as any)[key]) {
+                    if (this.localValues.has(key) || value !== (this.model as any)[key]) {
                         this.localValues.set(key, value);
                     }
                 })
@@ -40,7 +40,7 @@ class ViewModel<T> implements IViewModel<T> {
         });
     }
 
-    @action isPropertyDirty(key: string): boolean {
+    @action.bound isPropertyDirty(key: string): boolean {
         return this.localValues.has(key);
     }
 

--- a/src/create-view-model.ts
+++ b/src/create-view-model.ts
@@ -40,7 +40,7 @@ class ViewModel<T> implements IViewModel<T> {
         });
     }
 
-    isPropertyDirty(key: string): boolean {
+    @action isPropertyDirty(key: string): boolean {
         return this.localValues.has(key);
     }
 

--- a/src/create-view-model.ts
+++ b/src/create-view-model.ts
@@ -44,7 +44,7 @@ class ViewModel<T> implements IViewModel<T> {
         return this.localValues.has(key);
     }
 
-    @action submit() {
+    @action.bound submit() {
         this.localValues.keys().forEach((key) => {
             const source = this.localValues.get(key);
             const destination = (this.model as any)[key];
@@ -60,11 +60,11 @@ class ViewModel<T> implements IViewModel<T> {
         this.localValues.clear();
     }
 
-    @action reset() {
+    @action.bound reset() {
         this.localValues.clear();
     }
 
-    @action resetProperty(key: string) {
+    @action.bound resetProperty(key: string) {
         this.localValues.delete(key);
     }
 

--- a/src/create-view-model.ts
+++ b/src/create-view-model.ts
@@ -26,13 +26,13 @@ class ViewModel<T> implements IViewModel<T> {
                 enumerable: true,
                 configurable: true,
                 get: () => {
-                    if (this.localValues.has(key))
+                    if (isPropertyDirty(key))
                         return this.localValues.get(key);
                     else
                         return (this.model as any)[key];
                 },
                 set: action((value: any) => {
-                    if (this.localValues.has(key) || value !== (this.model as any)[key]) {
+                    if (isPropertyDirty(key) || value !== (this.model as any)[key]) {
                         this.localValues.set(key, value);
                     }
                 })
@@ -40,7 +40,7 @@ class ViewModel<T> implements IViewModel<T> {
         });
     }
 
-    @action.bound isPropertyDirty(key: string): boolean {
+    isPropertyDirty = (key: string): boolean => {
         return this.localValues.has(key);
     }
 


### PR DESCRIPTION
Hey,
I found problem with not bounded isPropertyDirty method and I've changed constructor method and added action.bound decorator to the method.

Error I had before after call that method: 
`Uncaught TypeError: Cannot read property 'localValues' of undefined`

Changed contructor to keep API stable.