### PR TITLE
Add whenAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.0
+* Introduced `whenAsync`, which is like normal `when`, except that this `when` will return a promise that resolves when the expression becomes truthy. See #66 and #68
+
 # 3.0.0
 
 ### Revamped `fromPromise`:

--- a/README.md
+++ b/README.md
@@ -323,6 +323,22 @@ test("expect store to load", t => {
 
 Returns **IDisposer** disposer function that can be used to cancel the when prematurely. Neither action or onTimeout will be fired if disposed
 
+## whenAsync
+
+Like normal `when`, except that this `when` will return a promise that resolves when the expression becomes truthy.
+
+**Parameters**
+
+-   `expr`  
+
+**Examples**
+
+```javascript
+await whenAsync(() => !state.someBoolean)
+```
+
+Returns **Promise** that won't resolve until the expression becomes truthy.
+
 ## keepAlive
 
 MobX normally suspends any computed value that is not in use by any reaction,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobx-utils",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Utility functions and common patterns for MobX",
   "main": "lib/mobx-utils.js",
   "typings": "lib/mobx-utils.d.ts",

--- a/src/when-async.js
+++ b/src/when-async.js
@@ -1,0 +1,13 @@
+import {when} from "mobx";
+
+/**
+ * Like normal `when`, except that this `when` will return a promise that resolves when the expression becomes truthy
+ *
+ * @example
+ * await whenAsync(() => !state.someBoolean)
+ *
+ * @export
+ * @param {() => boolean} fn see when, the expression to await
+ * @returns Promise for when an observable eventually matches some condition
+ */
+export let whenAsync = fn => new Promise(resolve => when(fn, resolve))


### PR DESCRIPTION
This PR adds an implementation of `whenAsync`, which is like normal `when`, except that this `when` will return a promise that resolves when the expression becomes truthy.

Feedback is greatly appreciated - I'm very excited to contribute to this project!

Closes #66 