### PR TITLE
feat(async-actions): add asyncActionWithCancel feature

### DIFF
--- a/test/async-action.ts
+++ b/test/async-action.ts
@@ -214,6 +214,125 @@ test("it should support logging", t => {
     }, 10)
 })
 
+test("it should support asyncActionWithCancel(cb, type) as decorator", t => {
+    const values: any[] = []
+
+    mobx.useStrict(true)
+
+    class X {
+        @mobx.observable a = 1;
+
+        @utils.asyncActionWithCancel(() => {}, 'takeLatest')
+        *f(initial: number) {
+            this.a = initial // this runs in action
+            try {
+                this.a = yield delay(100, 5, true) // and this as well!
+                yield delay(100, 0)
+                this.a = 4
+            } catch (e) {
+                this.a = e
+            }
+            return this.a
+        }
+    }
+
+    const x = new X()
+    mobx.reaction(() => x.a, v => values.push(v), { fireImmediately: true })
+
+    setTimeout(() => {
+        // TODO: mweh on any cast...
+        ;(x.f(/*test binding*/ 2) as any).then((v: number) => {
+            // note: ideally, type of v should be inferred..
+            t.is(v, 5)
+            t.deepEqual(values, [1, 2, 5])
+            t.is(x.a, 5) // correct instance modified?
+            t.end()
+        })
+    }, 10)
+})
+
+test("it should support cancel prev the same kinds of async generator actions in 'takeLatest' type", t => {
+    mobx.useStrict(true)
+    const values: any[] = []
+    const x = mobx.observable({ a: 1 })
+    mobx.reaction(() => x.a, v => values.push(v), { fireImmediately: true })
+
+    const f = utils.asyncActionWithCancel(() => {}, 'takeLatest')(function*(initial: number) {
+        x.a = initial // this runs in action
+        x.a = yield delay(100, 3) // and this as well!
+        yield delay(100, 0)
+        x.a = 4
+        return x.a
+    })
+
+    setTimeout(() => {
+        f(2)
+        f(3)
+        f(5).then((v: number) => {
+            // note: ideally, type of v should be inferred..
+            t.is(v, 4)
+            t.deepEqual(values, [1, 2, 3, 5, 3, 4])
+            t.end()
+        })
+    }, 10)
+})
+
+test("it should support cancel current async generator actions in 'takeLatest' type", t => {
+    mobx.useStrict(true)
+    const values: any[] = []
+    const x = mobx.observable({ a: 1 })
+    mobx.reaction(() => x.a, v => values.push(v), { fireImmediately: true })
+
+    let canceler
+    const f = utils.asyncActionWithCancel(cancel => canceler = cancel, 'takeLatest')(function*(initial: number) {
+        x.a = initial // this runs in action
+        x.a = yield delay(100, 3) // and this as well!
+        yield delay(100, 0)
+        x.a = 4
+        return x.a
+    })
+
+    setTimeout(() => {
+        f(2)
+        f(3)
+        f(5)
+        canceler()
+        setTimeout(() => {
+            t.is(x.a, 5)
+            t.deepEqual(values, [1, 2, 3, 5])
+            t.end()
+        }, 10)
+    }, 10)
+})
+
+test("it should support cancel all the same kinds of async generator actions in 'takeEvery' type", t => {
+    mobx.useStrict(true)
+    const values: any[] = []
+    const x = mobx.observable({ a: 1 })
+    mobx.reaction(() => x.a, v => values.push(v), { fireImmediately: true })
+
+    let canceler
+    const f = utils.asyncActionWithCancel(cancel => canceler = cancel, 'takeLatest')(function*(initial: number) {
+        x.a = initial // this runs in action
+        x.a = yield delay(100, 3) // and this as well!
+        yield delay(100, 0)
+        x.a = 4
+        return x.a
+    })
+
+    setTimeout(() => {
+        f(2)
+        f(3)
+        f(5)
+        canceler()
+        setTimeout(() => {
+            t.is(x.a, 5)
+            t.deepEqual(values, [1, 2, 3, 5])
+            t.end()
+        }, 10)
+    }, 10)
+})
+
 function stripEvents(events) {
     return events.map(e => {
         delete e.object


### PR DESCRIPTION
Refer to redux-saga, I would like to find a way to cancel actions' effects such as observable value changed after async function or entering *catch block code.*, especially for a singleton store in multiply components.

> The effects are mainly something will modify the observable value.

Like the concept of task in redux-saga, there will be two kinds of types actions: 
* ***takeEvery*** which means the async action can be called repeatedly at the same time. In this hand, the cancel function will cancel all the effects.
* ***takeLatest*** which means that when the action is called repeatedly， the prev call actions will be cancel automatically. The cancel function will cancel the latest call's effects. 

I would have the same usage likes *mobx-utils/asyncAction* but add a wrapper:
```javascript
   class Store {
       @observable loading = false;
       @observable text = 'nothing';
       @observable obj = {
            a: 1
       };
      @observable arr = [{ a: 2 }]

      @asyncActionWithCancel(cancel => this.cancelFetchData = cancel, 'takeEvery')
      *fetchData() {
            this.loading = true;
            try {
                const data = yield call('https://api.github.com', 'GET')  // mainly cancel in this timing
                this.loading = false;          // will not excute if cancel this action
                this.text = data.authorizations_url;   // will not excute
                this.obj.a++;   // will not excute
                this.arr[0].a++;   // will not excute
                alert(this.obj.a)   // will not excute
            } catch (e) {
                alert('error')    // will not excute
            }
      }
   }

  //component.js
  ...
  componentDidMount() {
    // for the type takeEvery, these three async action will be both effective，
    // for the type takeLatest, the last one will actually be effective.
    store.fetchData() 
    store.fetchData()
    store.fetchData()
 }
  componentWillMount() {
    // for takeEvery, this will cancel all the fetchData(); 
    //for takeLatest, this will cancel last one which is also the only one
    store.cancelFetchData() 
  }
  ...
```

1. The ***asyncActionWithCancel*** is a wrapper of original ***asyncAction***.
Its first arg is a function which will receive canceler.
Its second arg is the type of this action.('takeEvery', 'takeLatest')

2. In fact, in my private project, I would also wrap the ajax function after the keyword ***yield*** and inject the XmlHttpRequest Object into the cancel function which will abort the XmlHttpRequest in the same time.

ps: The cancel will only cancel the ineffective effects because there is no time travel to goback and therefore the developer need to initialize the state if used in a singleton store. 

It would be grateful if you can give me some suggestions for this pr.





