### PR TITLE
adding resetProperty to IViewModel

### DIFF
--- a/src/create-view-model.ts
+++ b/src/create-view-model.ts
@@ -16,9 +16,10 @@ export interface IViewModel<T> {
     submit(): void
     isDirty: boolean
     isPropertyDirty(key: string): boolean
+    resetProperty(key: string): void
 }
 
-const RESERVED_NAMES = ["model", "reset", "submit", "isDirty", "isPropertyDirty"]
+const RESERVED_NAMES = ["model", "reset", "submit", "isDirty", "isPropertyDirty", "resetProperty"]
 
 class ViewModel<T> implements IViewModel<T> {
     localValues: ObservableMap<any, any> = observable.map({})


### PR DESCRIPTION
this is the fix for [issue#117: IViewModel is missing resetProperty(propName: string): void;](https://github.com/mobxjs/mobx-utils/issues/117)