### PR TITLE
feat: add `moveItem` array utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,26 @@ Returns true if the provided value is a promise-based observable.
 
 Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
+## moveItem
+
+Moves an item from one position to another, checking that the indexes given are within bounds.
+
+**Parameters**
+
+-   `target` **ObservableArray&lt;T>** 
+-   `fromIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+-   `toIndex` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+**Examples**
+
+```javascript
+const source = observable([1, 2, 3])
+moveItem(source, 0, 1)
+console.log(source.map(x => x)) // [2, 1, 3]
+```
+
+Returns **ObservableArray&lt;T>** 
+
 ## lazyObservable
 
 `lazyObservable` creates an observable around a `fetch` method that will not be invoked

--- a/src/array.ts
+++ b/src/array.ts
@@ -1,0 +1,60 @@
+import { IObservableArray } from "mobx/lib/types/observablearray"
+
+/**
+ * Moves an item from one position to another, checking that the indexes given are within bounds.
+ * 
+ * @example
+ * const source = observable([1, 2, 3])
+ * moveItem(source, 0, 1)
+ * console.log(source.map(x => x)) // [2, 1, 3]
+ * 
+ * @export
+ * @param {ObservableArray<T>} target 
+ * @param {number} fromIndex 
+ * @param {number} toIndex 
+ * @returns {ObservableArray<T>}
+ */
+export function moveItem<T>(target: IObservableArray<T>, fromIndex: number, toIndex: number) {
+    checkIndex(target, fromIndex)
+    checkIndex(target, toIndex)
+    if (fromIndex === toIndex) {
+        return
+    }
+    const oldItems = (target as any).$mobx.values
+    let newItems: T[]
+    if (fromIndex < toIndex) {
+        newItems = [
+            ...oldItems.slice(0, fromIndex),
+            ...oldItems.slice(fromIndex + 1, toIndex + 1),
+            oldItems[fromIndex],
+            ...oldItems.slice(toIndex + 1)
+        ]
+    } else {
+        // toIndex < fromIndex
+        newItems = [
+            ...oldItems.slice(0, toIndex),
+            oldItems[fromIndex],
+            ...oldItems.slice(toIndex, fromIndex),
+            ...oldItems.slice(fromIndex + 1)
+        ]
+    }
+    target.replace(newItems)
+    return target
+}
+
+/**
+ * Checks whether the specified index is within bounds. Throws if not.
+ * 
+ * @private
+ * @param {ObservableArray<any>} target 
+ * @param {number }index 
+ */
+function checkIndex(target: IObservableArray<any>, index: number) {
+    if (index < 0) {
+        throw new Error(`[mobx.array] Index out of bounds: ${index} is negative`)
+    }
+    const length = (target as any).$mobx.values.length
+    if (index >= length) {
+        throw new Error(`[mobx.array] Index out of bounds: ${index} is not smaller than ${length}`)
+    }
+}

--- a/src/mobx-utils.ts
+++ b/src/mobx-utils.ts
@@ -1,4 +1,5 @@
 export * from "./from-promise"
+export * from "./array"
 export * from "./lazy-observable"
 export * from "./from-resource"
 export * from "./observable-stream"

--- a/test/__snapshots__/array.ts.snap
+++ b/test/__snapshots__/array.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`it throws when index is out of bounds 1`] = `"[mobx.array] Index out of bounds: -1 is negative"`;
+
+exports[`it throws when index is out of bounds 2`] = `"[mobx.array] Index out of bounds: 3 is not smaller than 3"`;

--- a/test/array.ts
+++ b/test/array.ts
@@ -1,0 +1,23 @@
+import * as utils from "../src/mobx-utils"
+import { observable } from "mobx"
+import { moveItem } from "../src/mobx-utils"
+
+test("it should move the item as expected", () => {
+    const source = observable<number>([1, 2, 3])
+    expect(moveItem(source, 0, 1)).toBe(source)
+    expect(source[0]).toBe(2)
+    expect(source[1]).toBe(1)
+    expect(source[2]).toBe(3)
+
+    moveItem(source, 1, 0)
+
+    expect(source[0]).toBe(1)
+    expect(source[1]).toBe(2)
+    expect(source[2]).toBe(3)
+})
+
+test("it throws when index is out of bounds", () => {
+    const source = observable<number>([1, 2, 3])
+    expect(() => moveItem(source, 0, -1)).toThrowErrorMatchingSnapshot()
+    expect(() => moveItem(source, 0, 3)).toThrowErrorMatchingSnapshot()
+})


### PR DESCRIPTION
Ripped from MobX with the deprecation warning removed.