### PR TITLE
Make IObservableStream overload order match RXJS Subscribable

### DIFF
--- a/src/observable-stream.ts
+++ b/src/observable-stream.ts
@@ -21,8 +21,8 @@ export interface ISubscription {
 }
 
 export interface IObservableStream<T> {
-    subscribe(observer: (value: T) => void): ISubscription
     subscribe(observer: IStreamObserver<T>): ISubscription
+    subscribe(observer: (value: T) => void): ISubscription
     //   [Symbol.observable](): IObservable;
 }
 


### PR DESCRIPTION
After upgrading to from RXJS 6.2.x to 6.3.x I started having some type inference failures when converting from mobx-util's `IObservableStream`:


```ts
import * as rxjs from 'rxjs';
import { IObservableStream, toStream } from 'mobx-utils';

const stream: IObservableStream<string> = toStream(() => 'hello world');
const rxjsStream = rxjs.from(stream); // rxjsStream: rxjs.Observable<{}>
```

Here the type of `rxjsStream` should be `rxjs.Observable<string>`, but it's inferred as `rxjs.Observable<{}>`. I traced the cause of this down to a change in the definition of RXJS' `Subscribable`:

```ts
// 6.2.x
interface Sub`Sscribable<T> {
  subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void), error?: (error: any) => void, complete?: () => void): Unsubscribable;
}
```

changed to

```ts
// 6.3.x
interface Subscribable<T> {
  subscribe(observer?: PartialObserver<T>): Unsubscribable;
  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
}
```

I'm still not exactly sure why this breaks the inference, but I noticed that the order of the overloads in the new definition of `Subscribable` is the opposite of the corresponding overloads in `IObservableStream`:

```ts
export interface IObservableStream<T> {
  subscribe(observer: (value: T) => void): ISubscription;
  subscribe(observer: IStreamObserver<T>): ISubscription;
}
```

By reversing the order so that it matches that of the new `Subscribable`, it seems to fix the issue.