### PR TITLE
Add defaultFulfilled option to case

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the status of the promise. The returned object has the following observable prop
 
 And the following methods:
 
--   `case({fulfilled, rejected, pending})`: maps over the result using the provided handlers, or returns `undefined` if a handler isn't available for the current promise state.
+-   `case({fulfilled, rejected, pending})`: maps over the result using the provided handlers. If no handler is available, returns the value of the promise for the `fulfilled` state, otherwise returns `undefined`.
 -   `then((value: TValue) => TResult1 | PromiseLike<TResult1>, [(rejectReason: any) => any])`: chains additional handlers to the provided promise.
 
 The returned object implements `PromiseLike<TValue>`, so you can chain additional `Promise` handlers using `then`. You may also use it with `await` in `async` functions.

--- a/src/from-promise.ts
+++ b/src/from-promise.ts
@@ -9,7 +9,7 @@ export const REJECTED = "rejected"
 
 export type IBasePromiseBasedObservable<T> = {
     isPromiseBasedObservable: true
-    case<U>(handlers: { pending?: () => U; fulfilled?: (t: T) => U; rejected?: (e: any) => U }): U
+    case<U>(handlers: { pending?: () => U; fulfilled?: (t: T) => U; rejected?: (e: any) => U }, defaultFulfilled?: boolean): U
 } & PromiseLike<T>
 
 export type IPendingPromise = {
@@ -41,7 +41,7 @@ function caseImpl<U, T>(handlers: {
         case REJECTED:
             return handlers.rejected && handlers.rejected(this.value)
         case FULFILLED:
-            return handlers.fulfilled && handlers.fulfilled(this.value)
+            return handlers.fulfilled ? handlers.fulfilled(this.value) : this.value
     }
 }
 

--- a/test/from-promise.js
+++ b/test/from-promise.js
@@ -233,6 +233,24 @@ test("case method, rejection", done => {
     )
 })
 
+test("case method, returns fulfilled value by default", done => {
+    const p = Promise.resolve(2)
+    const obs = utils.fromPromise(p)
+
+    let mapping = { pending: () => 1 }
+
+    let mapped = obs.case(mapping)
+    expect(mapped).toBe(1)
+    mobx.when(
+        () => obs.state === "fulfilled",
+        () => {
+            let mapped = obs.case(mapping)
+            expect(mapped).toBe(2)
+            done()
+        }
+    )
+})
+
 test("case method, returns undefined when handler is missing", done => {
     const p = Promise.resolve()
     const obs = utils.fromPromise(p)


### PR DESCRIPTION
I saw a colleague writing something like this today:

```
const foo = fromPromise(fetchFoo());
const { bar, foobar } = foo.case({
    fulfilled: value => value,
    pending: value => ({ bar: "loading...", foobar: false }),
    rejected: value => ({ bar: "error", foobar: false }),
});
```

This is basically fine, but the `value => value` just looked weird. This new argument gives you the option to rewrite the above into:

```
const foo = fromPromise(fetchFoo());
const { bar, foobar } = foo.case({
    pending: value => ({ bar: "loading...", foobar: false }),
    rejected: value => ({ bar: "error", foobar: false }),
}, true);
```

Sure, you need to know how the implementation works, but to me personally this feels like an improvement over having a function that only passes on what it receives.