### PR TITLE
Bugfix: createViewModel to honor the non-enumerability of a property

### DIFF
--- a/src/create-view-model.ts
+++ b/src/create-view-model.ts
@@ -49,8 +49,11 @@ export class ViewModel<T> implements IViewModel<T> {
                 const derivation = _getAdministration(model, key).derivation // Fixme: there is no clear api to get the derivation
                 this.localComputedValues.set(key, computed(derivation.bind(this)))
             }
+
+            const { enumerable } = Object.getOwnPropertyDescriptor(model, key)
+
             Object.defineProperty(this, key, {
-                enumerable: true,
+                enumerable,
                 configurable: true,
                 get: () => {
                     if (isComputedProp(model, key)) return this.localComputedValues.get(key).get()


### PR DESCRIPTION
It is quite common pattern (at least in our projects) to have a non enumerable properties that use spread to access `this`. When createViewModel is used to create a view model of such object, the non-enumerability of the property is lost and usage if spread operator or Object.entries on `this` causes a cycle in the mobx computation. The small change here propagates the enumerability of the models' property to the newly created view model.