### PR TITLE
set started to false when calling lazyObservable.reset to allow further update to lazyObservable.

### DIFF
--- a/src/lazy-observable.ts
+++ b/src/lazy-observable.ts
@@ -59,6 +59,7 @@ export function lazyObservable<T>(
         return value.get()
     }
     let resetFnc = action("lazyObservable-reset", () => {
+        started = false
         value.set(initialValue)
         return value.get()
     })

--- a/test/lazy-observable.js
+++ b/test/lazy-observable.js
@@ -87,6 +87,10 @@ test("lazy observable reset", done => {
 
     setTimeout(() => {
         expect(lo.current()).toBe(1)
-        done()
     }, 200)
+
+    setTimeout(() => {
+        expect(lo.current()).toBe(2)
+        done()
+    }, 250)
 })


### PR DESCRIPTION
I am seeing a wired bug(or a feature, I am not 100% sure) where after I call lazyObservable.reset, lazyObservable ignores the fetch function and always return the initial value. I am not sure if that's expected but I would like to have lazyObservable continue to honor the fetch function after reset.
By setting started to false, the`current` function will call the fetch function when it's being invoked. I know this will be a breaking change but let me know what do you guys think.