### PR TITLE
Fix: guard around unobserveRecursively to avoid error being thrown

### DIFF
--- a/src/deepObserve.ts
+++ b/src/deepObserve.ts
@@ -83,8 +83,10 @@ export function deepObserve<T = any>(
                 )
                 // update paths
                 for (let i = change.index + change.addedCount; i < change.object.length; i++) {
-                    const entry = entrySet.get(change.object[i])
-                    if (entry) entry.path = "" + i
+                    if (isRecursivelyObservable(change.object[i])) {
+                        const entry = entrySet.get(change.object[i])
+                        if (entry) entry.path = "" + i
+                    }
                 }
                 break
         }

--- a/src/deepObserve.ts
+++ b/src/deepObserve.ts
@@ -29,6 +29,10 @@ function buildPath(entry: Entry): string {
     return res.reverse().join("/")
 }
 
+function isRecursivelyObservable(thing: any) {
+    return isObservableObject(thing) || isObservableArray(thing) || isObservableMap(thing)
+}
+
 /**
  * Given an object, deeply observes the given object.
  * It is like `observe` from mobx, but applied recursively, including all future children.
@@ -90,10 +94,6 @@ export function deepObserve<T = any>(
                 }
                 break
         }
-    }
-
-    function isRecursivelyObservable(thing: any) {
-        return isObservableObject(thing) || isObservableArray(thing) || isObservableMap(thing)
     }
 
     function observeRecursively(thing: any, parent: Entry, path: string) {

--- a/test/deepObserve.ts
+++ b/test/deepObserve.ts
@@ -22,6 +22,22 @@ function assertChanges<T>(x: T, fn: (x: T) => void) {
     expect(events).toMatchSnapshot()
 }
 
+test("not throwing on primitive value changes", () => {
+    // deepObserve uses a WeakMap to track what is being observed.
+    // WeakMaps can only contain objects as their keys, not primitive values.
+    // Certain JS runtimes throw when passing a non-object to #get, #set or #has.
+    // deepObserve should not throw on primitive value changes, but still observe them.
+    expect(() => {
+        const x = observable({ a: 1 })
+        const d = deepObserve(x, (change) => {
+            expect(change.oldValue).toBe(1)
+            expect(change.newValue).toBe(2)
+        });
+
+        x.a = 2
+    }).not.toThrow();
+})
+
 test("basic & dispose", () => {
     const x = observable({ a: 1, b: { z: 3 } })
     const events: any[] = []


### PR DESCRIPTION
# What this does
When deepObserve crawls through the target, `observeRecursively` verifies whether the `thing` it finds is an observable array, -object or -map prior to observing it and going deeper. This pull request applies the same check to `unobserveRecursively`.

# Motivation
I upgraded React Native in one of my projects earlier today. One of the changes was the addition of a 64-bit release variant on the Android side. I had overridden JSC to a different version some time ago, but that ended up not being included in the 64-bit binary of my app. It used whatever version RN 0.58 ships with.

I found out that code which previously worked fine no longer did. I have a store similar to:

````js
const userStore = observable({
    models: observable.map(),
    status: 'logged-out'
})
````

I then deeply observe changes to this store.
````js
deepObserve(userStore, change => /* ... */)
````

Upon attempting to log in, I make the following change:
````js
userStore.status = 'logging-in';
````

And an error is thrown from `entrySet.get(thing)` in `unobserveRecursively`:
`A WeakMap cannot have a non-object key.`

`deepObserve` will attempt to unobserve the old value `"logged-out"` - a primitive value. According to the spec, WeakMaps only support objects as keys. It seems that most JS engines are pretty forgiving (I cannot reproduce it in V8) and just return `undefined` when you attempt to pass a string to `entrySet.get()`. 

Alas, this particular version of JSC doesn't like it _at all_ and explodes. It is impossible to remove something that cannot be added in the first place, so using the same isObservableArray|Object|Map checks should suffice.