### PR TITLE
Add pending observable in lazyObservable

### DIFF
--- a/src/lazy-observable.ts
+++ b/src/lazy-observable.ts
@@ -1,11 +1,11 @@
 import { IDENTITY } from "./utils"
-import { observable, action, _allowStateChanges, IObservableValue, runInAction } from "mobx"
+import { observable, action, _allowStateChanges, IObservableValue } from "mobx"
 
 export interface ILazyObservable<T> {
     current(): T
     refresh(): T
     reset(): T
-    pending: IObservableValue<boolean>
+    pending: boolean
 }
 
 /**
@@ -39,6 +39,7 @@ export interface ILazyObservable<T> {
  *     current(): T,
  *     refresh(): T,
  *     reset(): T
+ *     pendind: boolean
  * }}
  */
 
@@ -48,13 +49,11 @@ export function lazyObservable<T>(
 ): ILazyObservable<T> {
     let started = false
     const value = observable.box(initialValue, { deep: false })
-    const pending = observable.box(true)
+    const pending = observable.box(false)
     let currentFnc = () => {
         if (!started) {
             started = true
-            runInAction(() => {
-                pending.set(false)
-            })
+            pending.set(true)
             fetch((newValue: T) => {
                 _allowStateChanges(true, () => {
                     value.set(newValue)
@@ -81,6 +80,8 @@ export function lazyObservable<T>(
         reset: () => {
             return resetFnc()
         },
-        pending
+        get pending() {
+            return pending.get()
+        }
     }
 }

--- a/test/lazy-observable.js
+++ b/test/lazy-observable.js
@@ -90,3 +90,19 @@ test("lazy observable reset", done => {
         done()
     }, 200)
 })
+
+test("lazy observable pending", done => {
+    const lo = utils.lazyObservable(sink => new Promise(resolve => {
+        setTimeout(resolve, 100)
+    }).then(sink))
+
+    expect(lo.pending).toBeFalsy()
+
+    lo.current()
+    expect(lo.pending).toBeTruthy()
+
+    setTimeout(() => {
+        expect(lo.pending).toBeFalsy()
+        done()
+    }, 150)
+})


### PR DESCRIPTION
At the first observable evaluation or when `refresh` is trigger, it must be awesome to know that a refresh action is performing.

This PR add a `pending` observable to a LazyObservable letting us know when a refresh action is running