### PR TITLE
Bugfix (issue-191): Add a guard for missing property descriptor when inheriting enumerable

### DIFF
--- a/src/create-view-model.ts
+++ b/src/create-view-model.ts
@@ -57,10 +57,11 @@ export class ViewModel<T> implements IViewModel<T> {
                 this.localComputedValues.set(key, computed(derivation.bind(this)))
             }
 
-            const { enumerable } = Object.getOwnPropertyDescriptor(model, key)
+            const descriptor = Object.getOwnPropertyDescriptor(model, key);
+            const additionalDescriptor = descriptor ? { enumerable: descriptor.enumerable } : {};
 
             Object.defineProperty(this, key, {
-                enumerable,
+                ...additionalDescriptor,
                 configurable: true,
                 get: () => {
                     if (isComputedProp(model, key)) return this.localComputedValues.get(key).get()


### PR DESCRIPTION
My change in #169 was not accounting for the case that the property is not necessary an own property of the source object. Added a guard in similar way suggested by @mweststrate at https://github.com/mobxjs/mobx-utils/issues/191#issuecomment-487906280 

Sorry for the logic hiccup.