### PR TITLE
Fix: reinstate createViewModel unobserved properties

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,12 +24,12 @@ export function addHiddenProp(object: any, propName: string, value: any) {
     })
 }
 
-const deepFunctions = (x: any): any => {
-    return x && x !== Object.prototype && Object.getOwnPropertyNames(x).concat(deepFunctions(Object.getPrototypeOf(x)) || []);
+const deepFields = (x: any): any => {
+    return x && x !== Object.prototype && Object.getOwnPropertyNames(x).concat(deepFields(Object.getPrototypeOf(x)) || []);
 }
-const distinctDeepFunctions = (x: any) => {
-    const deepFunctionsIndistinct = deepFunctions(x);
-    const deepFunctionsDistinct = deepFunctionsIndistinct.filter((item: any, index: number) => deepFunctionsIndistinct.indexOf(item) === index);
-    return deepFunctionsDistinct;
+const distinctDeepFields = (x: any) => {
+    const deepFieldsIndistinct = deepFields(x);
+    const deepFieldsDistinct = deepFieldsIndistinct.filter((item: any, index: number) => deepFieldsIndistinct.indexOf(item) === index);
+    return deepFieldsDistinct;
 };
-export const getAllMethodsAndProperties = (x: any): any => distinctDeepFunctions(x).filter((name: string) => name !== "constructor" && !~name.indexOf("__"));
+export const getAllMethodsAndProperties = (x: any): any => distinctDeepFields(x).filter((name: string) => name !== "constructor" && !~name.indexOf("__"));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,14 +24,9 @@ export function addHiddenProp(object: any, propName: string, value: any) {
     })
 }
 
-const isProperty = (x: any, name: any) => (x.hasOwnProperty(name));
-const isGetter = (x: any, name: any) => (Object.getOwnPropertyDescriptor(x, name) || {}).get
-const isFunction = (x: any, name: any) => typeof x[name] === "function";
-const deepFunctions = (x: any): any => 
-  x && x !== Object.prototype && 
-  Object.getOwnPropertyNames(x)
-    .filter(name => isGetter(x, name) || isFunction(x, name) || isProperty(x, name))
-    .concat(deepFunctions(Object.getPrototypeOf(x)) || []);
+const deepFunctions = (x: any): any => {
+    return x && x !== Object.prototype && Object.getOwnPropertyNames(x).concat(deepFunctions(Object.getPrototypeOf(x)) || []);
+}
 const distinctDeepFunctions = (x: any) => {
     const deepFunctionsIndistinct = deepFunctions(x);
     const deepFunctionsDistinct = deepFunctionsIndistinct.filter((item: any, index: number) => deepFunctionsIndistinct.indexOf(item) === index);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,12 +24,13 @@ export function addHiddenProp(object: any, propName: string, value: any) {
     })
 }
 
+const isProperty = (x: any, name: any) => (x.hasOwnProperty(name));
 const isGetter = (x: any, name: any) => (Object.getOwnPropertyDescriptor(x, name) || {}).get
 const isFunction = (x: any, name: any) => typeof x[name] === "function";
 const deepFunctions = (x: any): any => 
   x && x !== Object.prototype && 
   Object.getOwnPropertyNames(x)
-    .filter(name => isGetter(x, name) || isFunction(x, name))
+    .filter(name => isGetter(x, name) || isFunction(x, name) || isProperty(x, name))
     .concat(deepFunctions(Object.getPrototypeOf(x)) || []);
 const distinctDeepFunctions = (x: any): any => Array.from(new Set(deepFunctions(x)));
 export const getAllMethodsAndProperties = (x: any): any => distinctDeepFunctions(x).filter((name: string) => name !== "constructor" && !~name.indexOf("__"));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,5 +32,9 @@ const deepFunctions = (x: any): any =>
   Object.getOwnPropertyNames(x)
     .filter(name => isGetter(x, name) || isFunction(x, name) || isProperty(x, name))
     .concat(deepFunctions(Object.getPrototypeOf(x)) || []);
-const distinctDeepFunctions = (x: any): any => Array.from(new Set(deepFunctions(x)));
+const distinctDeepFunctions = (x: any) => {
+    const deepFunctionsIndistinct = deepFunctions(x);
+    const deepFunctionsDistinct = deepFunctionsIndistinct.filter((item: any, index: number) => deepFunctionsIndistinct.indexOf(item) === index);
+    return deepFunctionsDistinct;
+};
 export const getAllMethodsAndProperties = (x: any): any => distinctDeepFunctions(x).filter((name: string) => name !== "constructor" && !~name.indexOf("__"));

--- a/test/create-view-model.ts
+++ b/test/create-view-model.ts
@@ -101,10 +101,10 @@ function tests(model) {
     expect(vr).toBe("tea:true,interested:Vader,Madonna,Tarzan,unobservedProp:testing,usersCount:3") // change NOT reflected in view model
     expect(viewModel.isDirty).toBe(true)
 
-    const newUsers = ["Putin", "Madonna", "Tarzan"]
+    const newUsers = ["Putin", "Madonna", "Tarzan", "Rocky"]
     mobx.runInAction(() => (viewModel.usersInterested = newUsers))
     expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,unobservedProp:testing,usersCount:3")
-    expect(vr).toBe("tea:true,interested:Putin,Madonna,Tarzan,unobservedProp:testing testing,usersCount:3")
+    expect(vr).toBe("tea:true,interested:Putin,Madonna,Tarzan,Rocky,unobservedProp:testing testing,usersCount:4")
     expect(viewModel.isDirty).toBe(true)
     expect(viewModel.isPropertyDirty("title")).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(true)
@@ -119,7 +119,7 @@ function tests(model) {
 
     mobx.runInAction(() => model.usersInterested.push("Cersei"))
     expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,unobservedProp:testing testing,usersCount:4")
-    expect(vr).toBe("tea:false,interested:Putin,Madonna,Tarzan,unobservedProp:testing testing,usersCount:3") // change NOT reflected in view model bcs users are dirty
+    expect(vr).toBe("tea:false,interested:Putin,Madonna,Tarzan,Rocky,unobservedProp:testing testing,usersCount:4") // change NOT reflected in view model bcs users are dirty
     expect(viewModel.isDirty).toBe(true)
     expect(viewModel.isPropertyDirty("title")).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
@@ -172,7 +172,7 @@ function tests(model) {
         viewModel.unobservedProp = "new value"
     })
     expect(tr).toBe("tea:false,interested:Vader,Madonna,unobservedProp:testing testing,usersCount:2")
-    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,unobservedProp:new value,usersCount:3")
+    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,Rocky,unobservedProp:new value,usersCount:4")
     expect(viewModel.isDirty).toBe(true)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
     expect(viewModel.isPropertyDirty("title")).toBe(true)
@@ -185,11 +185,11 @@ function tests(model) {
         model.unobservedProp = "another new value"
     })
     expect(tr).toBe("coffee:false,interested:Vader,Madonna,unobservedProp:another new value,usersCount:2")
-    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,unobservedProp:new value,usersCount:3")
+    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,Rocky,unobservedProp:new value,usersCount:4")
 
     viewModel.submit()
-    expect(tr).toBe("cola:false,interested:Putin,Madonna,Tarzan,unobservedProp:new value,usersCount:3")
-    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,unobservedProp:new value,usersCount:3")
+    expect(tr).toBe("cola:false,interested:Putin,Madonna,Tarzan,Rocky,unobservedProp:new value,usersCount:4")
+    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,Rocky,unobservedProp:new value,usersCount:4")
     expect(viewModel.isDirty).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
     expect(viewModel.isPropertyDirty("title")).toBe(false)

--- a/test/create-view-model.ts
+++ b/test/create-view-model.ts
@@ -4,16 +4,18 @@ import * as mobx from "mobx";
 mobx.configure({ enforceActions: "observed" })
 
 class TodoClass {
-    @mobx.observable title;
-    @mobx.observable done;
-    @mobx.observable usersInterested;
+    @mobx.observable title: string;
+    @mobx.observable done: boolean;
+    @mobx.observable usersInterested: string[];
+    unobservedProp: string;
     @mobx.computed
-    get usersCount() {
+    get usersCount(): number {
         return this.usersInterested.length
     }
 }
 
-function Todo(title, done, usersInterested) {
+function Todo(title, done, usersInterested, unobservedProp) {
+    this.unobservedProp = unobservedProp;
     mobx.extendObservable(this, {
         title: title,
         done: done,
@@ -25,8 +27,7 @@ function Todo(title, done, usersInterested) {
 }
 
 test("test NON Class/decorator createViewModel behaviour", () => {
-    const model = new Todo("coffee", false, ["Vader", "Madonna"]);
-    
+    const model = new Todo("coffee", false, ["Vader", "Madonna"], "testing");
     tests(model);
 })
 
@@ -34,8 +35,8 @@ test("test Class/decorator createViewModel behaviour", () => {
     const model = new TodoClass();
     model.title = "coffee";
     model.done = false;
-    model.usersInterested = ["Vader", "Madonna"];    
-
+    model.usersInterested = ["Vader", "Madonna"];
+    model.unobservedProp = "testing";
     tests(model);
 })
 
@@ -51,6 +52,8 @@ function tests(model) {
             model.done +
             ",interested:" +
             model.usersInterested.slice().toString() +
+            ",unobservedProp:" +
+            model.unobservedProp +
             ",usersCount:" +
             model.usersCount
     })
@@ -62,42 +65,51 @@ function tests(model) {
             viewModel.done +
             ",interested:" +
             viewModel.usersInterested.slice().toString() +
+            ",unobservedProp:" +
+            viewModel.unobservedProp +
             ",usersCount:" +
             viewModel.usersCount
     })
 
-    expect(tr).toBe("coffee:false,interested:Vader,Madonna,usersCount:2")
-    expect(vr).toBe("coffee:false,interested:Vader,Madonna,usersCount:2")
+    expect(tr).toBe("coffee:false,interested:Vader,Madonna,unobservedProp:testing,usersCount:2")
+    expect(vr).toBe("coffee:false,interested:Vader,Madonna,unobservedProp:testing,usersCount:2")
 
     mobx.runInAction(() => (model.title = "tea"))
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,usersCount:2")
-    expect(vr).toBe("tea:false,interested:Vader,Madonna,usersCount:2") // change reflected in view model
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,unobservedProp:testing,usersCount:2")
+    expect(vr).toBe("tea:false,interested:Vader,Madonna,unobservedProp:testing,usersCount:2") // change reflected in view model
     expect(viewModel.isDirty).toBe(false)
 
     mobx.runInAction(() => model.usersInterested.push("Tarzan"))
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,usersCount:3")
-    expect(vr).toBe("tea:false,interested:Vader,Madonna,Tarzan,usersCount:3") // change reflected in view model
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,unobservedProp:testing,usersCount:3")
+    expect(vr).toBe("tea:false,interested:Vader,Madonna,Tarzan,unobservedProp:testing,usersCount:3") // change reflected in view model
     expect(viewModel.isDirty).toBe(false)
     expect(viewModel.changedValues.size).toBe(0)
 
     mobx.runInAction(() => (viewModel.done = true))
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,usersCount:3")
-    expect(vr).toBe("tea:true,interested:Vader,Madonna,Tarzan,usersCount:3")
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,unobservedProp:testing,usersCount:3")
+    expect(vr).toBe("tea:true,interested:Vader,Madonna,Tarzan,unobservedProp:testing,usersCount:3")
     expect(viewModel.isDirty).toBe(true)
     expect(viewModel.isPropertyDirty("title")).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(true)
     expect(viewModel.isPropertyDirty("usersInterested")).toBe(false)
+    expect(viewModel.isPropertyDirty("unobservedProp")).toBe(false)
     expect(viewModel.isPropertyDirty("usersCount")).toBe(false)
     expect(viewModel.changedValues.has("done")).toBe(true)
 
+    mobx.runInAction(() => (model.unobservedProp = "testing testing"))
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,unobservedProp:testing,usersCount:3") // change NOT reflected in model
+    expect(vr).toBe("tea:true,interested:Vader,Madonna,Tarzan,unobservedProp:testing,usersCount:3") // change NOT reflected in view model
+    expect(viewModel.isDirty).toBe(true)
+
     const newUsers = ["Putin", "Madonna", "Tarzan"]
     mobx.runInAction(() => (viewModel.usersInterested = newUsers))
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,usersCount:3")
-    expect(vr).toBe("tea:true,interested:Putin,Madonna,Tarzan,usersCount:3")
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,unobservedProp:testing,usersCount:3")
+    expect(vr).toBe("tea:true,interested:Putin,Madonna,Tarzan,unobservedProp:testing testing,usersCount:3")
     expect(viewModel.isDirty).toBe(true)
     expect(viewModel.isPropertyDirty("title")).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(true)
     expect(viewModel.isPropertyDirty("usersInterested")).toBe(true)
+    expect(viewModel.isPropertyDirty("unobservedProp")).toBe(false)
     expect(viewModel.isPropertyDirty("usersCount")).toBe(false)
     expect(viewModel.changedValues.has("done")).toBe(true)
 
@@ -106,72 +118,83 @@ function tests(model) {
     expect(viewModel.changedValues.has("done")).toBe(false)
 
     mobx.runInAction(() => model.usersInterested.push("Cersei"))
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,usersCount:4")
-    expect(vr).toBe("tea:false,interested:Putin,Madonna,Tarzan,usersCount:3") // change NOT reflected in view model bcs users are dirty
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,unobservedProp:testing testing,usersCount:4")
+    expect(vr).toBe("tea:false,interested:Putin,Madonna,Tarzan,unobservedProp:testing testing,usersCount:3") // change NOT reflected in view model bcs users are dirty
     expect(viewModel.isDirty).toBe(true)
     expect(viewModel.isPropertyDirty("title")).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
+    expect(viewModel.isPropertyDirty("unobservedProp")).toBe(false)
     expect(viewModel.isPropertyDirty("usersInterested")).toBe(true)
 
     // should reset
     viewModel.reset()
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,usersCount:4")
-    expect(vr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,usersCount:4")
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,unobservedProp:testing testing,usersCount:4")
+    expect(vr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,unobservedProp:testing testing,usersCount:4")
     expect(viewModel.isDirty).toBe(false)
     expect(viewModel.isPropertyDirty("title")).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
     expect(viewModel.isPropertyDirty("usersInterested")).toBe(false)
+    expect(viewModel.isPropertyDirty("unobservedProp")).toBe(false)
 
     mobx.runInAction(() => (viewModel.title = "beer"))
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,usersCount:4")
-    expect(vr).toBe("beer:false,interested:Vader,Madonna,Tarzan,Cersei,usersCount:4")
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,unobservedProp:testing testing,usersCount:4")
+    expect(vr).toBe("beer:false,interested:Vader,Madonna,Tarzan,Cersei,unobservedProp:testing testing,usersCount:4")
     expect(viewModel.isDirty).toBe(true)
     expect(viewModel.isPropertyDirty("title")).toBe(true)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
     expect(viewModel.isPropertyDirty("usersInterested")).toBe(false)
+    expect(viewModel.isPropertyDirty("unobservedProp")).toBe(false)
 
     mobx.runInAction(() => viewModel.resetProperty("title"))
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,usersCount:4")
-    expect(vr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,usersCount:4")
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,unobservedProp:testing testing,usersCount:4")
+    expect(vr).toBe("tea:false,interested:Vader,Madonna,Tarzan,Cersei,unobservedProp:testing testing,usersCount:4")
     expect(viewModel.isDirty).toBe(false)
     expect(viewModel.isPropertyDirty("title")).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
     expect(viewModel.isPropertyDirty("usersInterested")).toBe(false)
+    expect(viewModel.isPropertyDirty("unobservedProp")).toBe(false)
 
     mobx.runInAction(() => {
         model.usersInterested.pop()
         model.usersInterested.pop()
     })
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,usersCount:2")
-    expect(vr).toBe("tea:false,interested:Vader,Madonna,usersCount:2")
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,unobservedProp:testing testing,usersCount:2")
+    expect(vr).toBe("tea:false,interested:Vader,Madonna,unobservedProp:testing testing,usersCount:2")
     expect(viewModel.isDirty).toBe(false)
     expect(viewModel.isPropertyDirty("title")).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
     expect(viewModel.isPropertyDirty("usersInterested")).toBe(false)
+    expect(viewModel.isPropertyDirty("unobservedProp")).toBe(false)
 
     mobx.runInAction(() => {
         viewModel.title = "cola"
         viewModel.usersInterested = newUsers
+        viewModel.unobservedProp = "new value"
     })
-    expect(tr).toBe("tea:false,interested:Vader,Madonna,usersCount:2")
-    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,usersCount:3")
+    expect(tr).toBe("tea:false,interested:Vader,Madonna,unobservedProp:testing testing,usersCount:2")
+    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,unobservedProp:new value,usersCount:3")
     expect(viewModel.isDirty).toBe(true)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
     expect(viewModel.isPropertyDirty("title")).toBe(true)
     expect(viewModel.isPropertyDirty("usersInterested")).toBe(true)
+    expect(viewModel.isPropertyDirty("unobservedProp")).toBe(true)
 
     // model changes should not update view model which is dirty
-    mobx.runInAction(() => (model.title = "coffee"))
-    expect(tr).toBe("coffee:false,interested:Vader,Madonna,usersCount:2")
-    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,usersCount:3")
+    mobx.runInAction(() => {
+        model.title = "coffee"
+        model.unobservedProp = "another new value"
+    })
+    expect(tr).toBe("coffee:false,interested:Vader,Madonna,unobservedProp:another new value,usersCount:2")
+    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,unobservedProp:new value,usersCount:3")
 
     viewModel.submit()
-    expect(tr).toBe("cola:false,interested:Putin,Madonna,Tarzan,usersCount:3")
-    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,usersCount:3")
+    expect(tr).toBe("cola:false,interested:Putin,Madonna,Tarzan,unobservedProp:new value,usersCount:3")
+    expect(vr).toBe("cola:false,interested:Putin,Madonna,Tarzan,unobservedProp:new value,usersCount:3")
     expect(viewModel.isDirty).toBe(false)
     expect(viewModel.isPropertyDirty("done")).toBe(false)
     expect(viewModel.isPropertyDirty("title")).toBe(false)
     expect(viewModel.isPropertyDirty("usersInterested")).toBe(false)
+    expect(viewModel.isPropertyDirty("unobservedProp")).toBe(false)
 
     d1()
     d2()


### PR DESCRIPTION
This attends to https://github.com/mobxjs/mobx-utils/issues/205

I've also removed Set which was causing IE11 and createViewModel not to work. I'm guessing there's a very small subset of people using Mobx/Mobx-Utils/createViewModel and IE11 