### PR TITLE
add plain value support to task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* `task` now supports plain values as well.
+
 # 5.5.0
 
 _Note: the minimum required MobX version for this release has been bumped to `"mobx": "^4.13.1 || ^5.13.1"`_

--- a/src/action-async.ts
+++ b/src/action-async.ts
@@ -27,12 +27,7 @@ function getCurrentActionAsyncContext() {
     return actionAsyncContextStack[actionAsyncContextStack.length - 1]!
 }
 
-export async function task<R>(promise: Promise<R>): Promise<R> {
-    invariant(
-        typeof promise === "object" && typeof promise.then === "function",
-        "'task' expects a promise"
-    )
-
+export async function task<R>(value: R | PromiseLike<R>): Promise<R> {
     const ctx = getCurrentActionAsyncContext()
 
     const { runId, actionName, args, scope, actionRunInfo, step } = ctx
@@ -42,7 +37,7 @@ export async function task<R>(promise: Promise<R>): Promise<R> {
     currentlyActiveIds.delete(runId)
 
     try {
-        return await promise
+        return await value
     } finally {
         // only restart if it not a dangling promise (the action is not yet finished)
         if (unfinishedIds.has(runId)) {

--- a/test/action-async.ts
+++ b/test/action-async.ts
@@ -46,12 +46,13 @@ test("it should support async actions", async () => {
         x.a = await task(delay(100, 3))
         await task(delay(100, 0))
         x.a = 4
+        x.a = await task(5)
         return x.a
     })
 
     const v = await f(2)
-    expect(v).toBe(4)
-    expect(values).toEqual([1, 2, 3, 4])
+    expect(v).toBe(5)
+    expect(values).toEqual([1, 2, 3, 4, 5])
     expectNoActionsRunning()
 })
 


### PR DESCRIPTION
Like the name, make task support plain values (like await does)