### PR TITLE
fix actionAsync actions without task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fix for `actionAsync` giving errors when it didn't await a task inside.
 * `task` now supports plain values as well.
 
 # 5.5.0


### PR DESCRIPTION
Fixes an issue where actionAsync would misbehave if no task was awaited inside.
Also improves the error message to give some more info while at it.