### PR TITLE
Support IComputedOptions in createTransformer

### DIFF
--- a/src/create-transformer.ts
+++ b/src/create-transformer.ts
@@ -8,7 +8,7 @@ export type ITransformerParams<A, B> =
           onCleanup?: (resultObject: B | undefined, sourceObject?: A) => void
           debugNameGenerator?: (sourceObject?: A) => string
       }
-    | Exclude<IComputedValueOptions<B>, "name">
+    | Omit<IComputedValueOptions<B>, "name">
 
 let memoizationId = 0
 

--- a/test/create-transformer.ts
+++ b/test/create-transformer.ts
@@ -1354,3 +1354,18 @@ test("should respect debugNameGenerator argument", () => {
     objectName = m.getObserverTree(state, "title").observers[0].name
     expect(objectName).toBe("COFFEE-DEBUG")
 })
+
+test("supports computed value options", () => {
+    const events: number[][] = []
+    const xs = m.observable([1, 2, 3])
+    const xsLessThan = createTransformer(n => xs.filter(x => x < n), {
+        equals: m.comparer.structural
+    })
+
+    m.autorun(() => events.push(xsLessThan(3)))
+    expect(events).toEqual([[1, 2]])
+
+    events.length = 0
+    xs.push(4)
+    expect(events).toEqual([])
+})


### PR DESCRIPTION
In the same vein as #215, it would be great to use a custom equals
function with `createTransformer`, to avoid bubbling bubbling recomputes
of transformers that return arrays/maps/etc.

This commit passes the options through to the internal `computed`.  The
name option is not passed through, since that can be changed with
the `debugNameGenerator` option.