### PR TITLE
fix actionAsync when using promises that resolve immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix for `actionAsync` when awaiting promises that resolve immediately.
+
 # 5.5.1
 
 * Fix for `actionAsync` giving errors when it didn't await a task inside.


### PR DESCRIPTION
Basically when awaiting for promises that resolve immediately task continuations might get out of order. This PR ensures task continuations are kept in order by creating a "keep in order" promise trick.

Fixes #223 