### PR TITLE
Fix invalid `actionAsync` context when promises resolve at the same time in different actionAsync calls

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,10 +4,17 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "debug unit test",
-            "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
-            "args": ["-i", "${file}"],
-            // "preLaunchTask": "tsc: build - tsconfig.json"
+            "name": "Jest Current File",
+            "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            "args": ["--ci", "-i", "${fileBasenameNoExtension}"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+            },
+            "skipFiles": ["${workspaceFolder}/node_modules/**/*.js", "<node_internals>/**/*.js"],
+            "cwd": "${workspaceFolder}"
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix invalid `actionAsync` context when promises resolve at the same time in different actionAsync calls, by [xaviergonz](https://github.com/xaviergonz) through [#???](https://github.com/mobxjs/mobx-utils/pull/???)
+
 # 5.5.3
 
 * Support all `IComputedOptions` in `createTransformer`, by [@samdroid-apps](https://github.com/samdroid-apps) through [#224](https://github.com/mobxjs/mobx-utils/pull/224)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Fix invalid `actionAsync` context when promises resolve at the same time in different actionAsync calls, by [xaviergonz](https://github.com/xaviergonz) through [#???](https://github.com/mobxjs/mobx-utils/pull/???)
+* Fix invalid `actionAsync` context when promises resolve at the same time in different actionAsync calls, by [xaviergonz](https://github.com/xaviergonz) through [#240](https://github.com/mobxjs/mobx-utils/pull/240)
 
 # 5.5.3
 

--- a/src/action-async.ts
+++ b/src/action-async.ts
@@ -17,7 +17,7 @@ interface IActionAsyncContext {
 }
 
 let taskOrderPromise = Promise.resolve()
-const emptyFunction = () => {}
+const emptyFunction = () => Promise.resolve()
 
 const actionAsyncContextStack: IActionAsyncContext[] = []
 

--- a/src/action-async.ts
+++ b/src/action-async.ts
@@ -41,7 +41,9 @@ export async function task<R>(value: R | PromiseLike<R>): Promise<R> {
 
         // we use this trick to force a proper order of execution
         // even for immediately resolved promises
-        taskOrderPromise = taskOrderPromise.then(emptyFunction)
+        // we need to also use catch or else it won't work for older versions of node (< 10)
+        // since it would resolve them immediately
+        taskOrderPromise = taskOrderPromise.then(emptyFunction).catch(emptyFunction)
         await taskOrderPromise
 
         return ret


### PR DESCRIPTION
Fixes #239 
Also fixes jest configuration to run unit tests in vscode