### PR TITLE
add ref modifier to searchResults

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This is useful to replace one promise based observable with another, without goi
 ```javascript
 @observer
 class SearchResults extends React.Component {
-  @observable searchResults
+  @observable.ref searchResults
 
   componentDidUpdate(nextProps) {
     if (nextProps.query !== this.props.query)


### PR DESCRIPTION
technically this is more accurate as fromPromise returns promise with some fields being already observable, so there's no need to wrap the whole return value in another observable