### PR TITLE
Move OGM constructor docs to class head.

### DIFF
--- a/src/ObservableGroupMap.ts
+++ b/src/ObservableGroupMap.ts
@@ -29,12 +29,18 @@ interface GroupItemInfo {
  *
  * This observes the individual computed groupBy values and only updates the source and dest arrays
  * when there is an actual change, so this is far more efficient than, for example
- * `base.filter(i => groupBy(i) === 'we')`.
+ * `base.filter(i => groupBy(i) === 'we')`. Call #dispose() to stop tracking.
  *
  * No guarantees are made about the order of items in the grouped arrays.
  *
  * The resulting map of arrays is read-only. clear(), set(), delete() are not supported and
  * modifying the group arrays will lead to undefined behavior.
+ *
+ * @param {array} base The array to sort into groups.
+ * @param {function} groupBy The function used for grouping.
+ * @param options Object with properties:
+ *  `name`: Debug name of this ObservableGroupMap.
+ *  `keyToName`: Function to create the debug names of the observable group arrays.
  *
  * @example
  * const slices = observable([
@@ -71,16 +77,6 @@ export class ObservableGroupMap<G, T> extends ObservableMap<G, IObservableArray<
 
     private readonly _disposeBaseObserver: Lambda
 
-    /**
-     * Create a new ObservableGroupMap. This immediately observes all members of the array. Call
-     * #dispose() to stop tracking.
-     *
-     * @param base The array to sort into groups.
-     * @param groupBy The function used for grouping.
-     * @param options Object with properties:
-     *  `name`: Debug name of this ObservableGroupMap.
-     *  `keyToName`: Function to create the debug names of the observable group arrays.
-     */
     constructor(
         base: IObservableArray<T>,
         groupBy: (x: T) => G,

--- a/src/ObservableGroupMap.ts
+++ b/src/ObservableGroupMap.ts
@@ -47,7 +47,7 @@ interface GroupItemInfo {
  *     slicesByDay.get("we"))) // outputs 1, undefined
  * slices[0].day = "we" // outputs 0, [{ day: "we", hours: 12 }]
  */
-export class ObservableGroupMap<G, T> extends ObservableMap<G, IObservableArray<T & GroupItem>> {
+export class ObservableGroupMap<G, T> extends ObservableMap<G, IObservableArray<T>> {
     /**
      * Base observable array which is being sorted into groups.
      */
@@ -134,11 +134,6 @@ export class ObservableGroupMap<G, T> extends ObservableMap<G, IObservableArray<
         throw new Error("not supported")
     }
 
-    public get(key: G): IObservableArray<T> | undefined {
-        // override get to return IObservableArray<T> instead of IObservableArray<T & GroupItem>
-        return super.get(key)
-    }
-
     /**
      * Disposes all observers created during construction and removes state added to base array
      * items.
@@ -164,7 +159,7 @@ export class ObservableGroupMap<G, T> extends ObservableMap<G, IObservableArray<
     }
 
     private _removeFromGroupArr(key: G, itemIndex: number) {
-        const arr = super.get(key)!
+        const arr: IObservableArray<T & GroupItem> = super.get(key)!
         if (1 === arr.length) {
             super.delete(key)
         } else if (itemIndex === arr.length - 1) {

--- a/src/from-promise.ts
+++ b/src/from-promise.ts
@@ -1,5 +1,5 @@
-import { IObservableValue, action, extendObservable } from "mobx"
-import { IDENTITY, invariant } from "./utils"
+import { action, extendObservable } from "mobx"
+import { invariant } from "./utils"
 
 export type PromiseState = "pending" | "fulfilled" | "rejected"
 

--- a/src/from-resource.ts
+++ b/src/from-resource.ts
@@ -7,6 +7,15 @@ export interface IResource<T> {
     isAlive(): boolean
 }
 
+export function fromResource<T>(
+    subscriber: (sink: (newValue: T) => void) => void,
+    unsubscriber?: IDisposer
+): IResource<T | undefined>
+export function fromResource<T>(
+    subscriber: (sink: (newValue: T) => void) => void,
+    unsubscriber: IDisposer | undefined,
+    initialValue: T
+): IResource<T>
 /**
  * `fromResource` creates an observable whose current state can be inspected using `.current()`,
  * and which can be kept in sync with some external datasource that can be subscribed to.
@@ -71,15 +80,6 @@ export interface IResource<T> {
  *     isAlive(): boolean;
  * }}
  */
-export function fromResource<T>(
-    subscriber: (sink: (newValue: T) => void) => void,
-    unsubscriber?: IDisposer
-): IResource<T | undefined>
-export function fromResource<T>(
-    subscriber: (sink: (newValue: T) => void) => void,
-    unsubscriber: IDisposer | undefined,
-    initialValue: T
-): IResource<T>
 export function fromResource<T>(
     subscriber: (sink: (newValue: T) => void) => void,
     unsubscriber: IDisposer = NOOP,

--- a/src/lazy-observable.ts
+++ b/src/lazy-observable.ts
@@ -1,5 +1,4 @@
-import { IDENTITY } from "./utils"
-import { observable, action, _allowStateChanges, IObservableValue } from "mobx"
+import { observable, action, _allowStateChanges } from "mobx"
 
 export interface ILazyObservable<T> {
     current(): T

--- a/src/lazy-observable.ts
+++ b/src/lazy-observable.ts
@@ -7,6 +7,13 @@ export interface ILazyObservable<T> {
     pending: boolean
 }
 
+export function lazyObservable<T>(
+    fetch: (sink: (newValue: T) => void) => void
+): ILazyObservable<T | undefined>
+export function lazyObservable<T>(
+    fetch: (sink: (newValue: T) => void) => void,
+    initialValue: T
+): ILazyObservable<T>
 /**
  * `lazyObservable` creates an observable around a `fetch` method that will not be invoked
  * until the observable is needed the first time.
@@ -41,14 +48,6 @@ export interface ILazyObservable<T> {
  *     pending: boolean
  * }}
  */
-
-export function lazyObservable<T>(
-    fetch: (sink: (newValue: T) => void) => void
-): ILazyObservable<T | undefined>
-export function lazyObservable<T>(
-    fetch: (sink: (newValue: T) => void) => void,
-    initialValue: T
-): ILazyObservable<T>
 export function lazyObservable<T>(
     fetch: (sink: (newValue: T) => void) => void,
     initialValue: T | undefined = undefined

--- a/src/queue-processor.ts
+++ b/src/queue-processor.ts
@@ -3,7 +3,7 @@ import { IDisposer } from "./utils"
 
 /**
  * `queueProcessor` takes an observable array, observes it and calls `processor`
- * once for each item added to the observable array, optionally deboucing the action
+ * once for each item added to the observable array, optionally debouncing the action
  *
  * @example
  * const pendingNotifications = observable([])


### PR DESCRIPTION
ObservableGroupMap appeared twice in the Readme because the constructor of the class was documented. As recommended by https://github.com/documentationjs/documentation/blob/HEAD/docs/RECIPES.md#classes the constructor parameters should be documented in the class's documentation.

Regenerated Readme based on the current state using `yarn prepublishOnly`. Not sure why `lazyObservable ` and `fromResource` docs were removed. Can somebody explain?