### PR TITLE
Use incrementing internal IDs instead rnd(0-1000).

### DIFF
--- a/src/ObservableGroupMap.ts
+++ b/src/ObservableGroupMap.ts
@@ -77,11 +77,17 @@ export class ObservableGroupMap<G, T> extends ObservableMap<G, IObservableArray<
 
     private readonly _disposeBaseObserver: Lambda
 
+    private static lastId: number
+    private static nextId() {
+        if (!this.lastId) return (this.lastId = 1)
+        return ++this.lastId
+    }
+
     constructor(
         base: IObservableArray<T>,
         groupBy: (x: T) => G,
         {
-            name = "ogm" + ((Math.random() * 1000) | 0),
+            name = `ogm${ObservableGroupMap.nextId()}`,
             keyToName = (x) => "" + x,
         }: { name?: string; keyToName?: (group: G) => string } = {}
     ) {


### PR DESCRIPTION
## Scope

This is only relevant for environments which do not support `Symbol` (e.g. IE11). With Symbols, it's fine because `Symbol('foo') === Symbol('foo')` is guaranteed to be `false`.

## Objective

The current way of generating internal names is using random numbers in the range 0-1000. Thus, there is a risk of collisions in environments not supporting Symbols. 

There's a collision the latest at 1000 entries, practically it may happen much earlier, think of the [Birthday Problem](https://en.wikipedia.org/wiki/Birthday_problem).

This patch uses incrementing internal IDs which improves that from guaranteed collision at 1000 to guaranteed non-collision until `Number.MAX_SAFE_INTEGER` instances.

## Test

A test for this might look something like this:

    it("allows creating many instances without name collisions", (done) => {
        const data = observable([{ id: 1, a: "x" }])
        const quantity = 1001
        const mapmap = new Map()

        for (let i = 0; i < quantity; i++) {
            const ogm = new ObservableGroupMap(data, (e) => e.a)
            mapmap.set(ogm._ogmInfoKey, ogm)
        }

        console.log(mapmap.size, quantity)
        assert(mapmap.size == quantity)

        done()
    })

However, to make this test work, one needs to make `_ogmInfoKey` non-private to be able to compile the code and change

    this._ogmInfoKey = ("function" == typeof Symbol
        ? Symbol("ogmInfo" + name)
        : "__ogmInfo" + name) as any

to

    this._ogmInfoKey = ("__ogmInfo" + name) as any

for emulating an environment without Symbol. Thus, I didn't include it in the PR.