### PR TITLE
Fixed reused now() tickers initially returning old values (#271)

### DIFF
--- a/src/now.ts
+++ b/src/now.ts
@@ -47,6 +47,7 @@ function createIntervalTicker(interval: number): IResource<number> {
     let subscriptionHandle: any
     return fromResource<number>(
         (sink) => {
+            sink(Date.now())
             subscriptionHandle = setInterval(() => sink(Date.now()), interval)
         },
         () => {
@@ -57,9 +58,10 @@ function createIntervalTicker(interval: number): IResource<number> {
 }
 
 function createAnimationFrameTicker(): IResource<number> {
-    let subscriptionHandle: number
     const frameBasedTicker = fromResource<number>(
         (sink) => {
+            sink(Date.now())
+
             function scheduleTick() {
                 window.requestAnimationFrame(() => {
                     sink(Date.now())

--- a/test/now.js
+++ b/test/now.js
@@ -30,3 +30,27 @@ test("now should be up to date outside reaction, #40", (done) => {
         done()
     }, 500)
 })
+
+test("now should be up to date when ticker is reactivated, #271", (done) => {
+    let d1
+    mobx.autorun((r) => {
+        d1 = utils.now(100)
+        r.dispose()
+    })
+
+    let d2
+    mobx.autorun(
+        (r) => {
+            d2 = utils.now(100)
+            r.dispose()
+        },
+        {
+            delay: 150,
+        }
+    )
+
+    setTimeout(() => {
+        expect(d1).toBeLessThan(d2)
+        done()
+    }, 200)
+})


### PR DESCRIPTION
Fixes issue #271.

Solved by sink-ing the current time when the ticker is subscribed to. Added an unit test for good measure which currently fails on master.