### PR TITLE
Use computedFn name if explicitly set in options

### DIFF
--- a/src/computedFn.ts
+++ b/src/computedFn.ts
@@ -77,7 +77,7 @@ export function computedFn<T extends (...args: any[]) => any>(
             },
             {
                 ...opts,
-                name: `computedFn(${fn.name}#${++i})`,
+                name: `computedFn(${opts.name || fn.name}#${++i})`,
             }
         )
         entry.set(c)


### PR DESCRIPTION
Quite simple change. Unfortunately, I was unable to retrieve the name in a test, any suggestion is welcome.