### PR TITLE
Make observable promise's values safer type wise

### DIFF
--- a/src/from-promise.ts
+++ b/src/from-promise.ts
@@ -8,7 +8,7 @@ export const FULFILLED = "fulfilled"
 export const REJECTED = "rejected"
 
 type CaseHandlers<U, T> = {
-    pending?: (t?: T) => U
+    pending?: (t?: unknown) => U
     fulfilled?: (t: T) => U
     rejected?: (e: any) => U
 }
@@ -20,7 +20,7 @@ export interface IBasePromiseBasedObservable<T> extends PromiseLike<T> {
 
 export type IPendingPromise = {
     readonly state: "pending"
-    readonly value: any // can be error, T or nothing at this point
+    readonly value: unknown // can be error, T or nothing at this point
 }
 
 export type IFulfilledPromise<T> = {
@@ -30,7 +30,7 @@ export type IFulfilledPromise<T> = {
 
 export type IRejectedPromise = {
     readonly state: "rejected"
-    readonly value: any
+    readonly value: unknown
 }
 
 export type IPromiseBasedObservable<T> = IBasePromiseBasedObservable<T> &


### PR DESCRIPTION
This PR replaces `any` typing for observable promise's value field by `unknow`. `unknown` is the type-safe counterpart to `any`, so it should allow detecting unsafe branches in consumers code.

Typically before this change, this would pass type checking:

```ts
const observablePromise = fromPromise(Promise.resolve("a string"))

const aString: string = observablePromise.value
```

whereas with this change, one would need to write
```ts
const observablePromise = fromPromise(Promise.resolve("a string"))

if(observablePromise.state === "fulfilled") {
  const aString: string = observablePromise.value
}
```

It is important to note that it will probably make some code that was compiling before failing since `any` was defacto disabling type checking.

This closes https://github.com/mobxjs/mobx-utils/issues/291
