### PR TITLE
Fix fromPromise.resolve() returning undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,9 +64,7 @@
     "state management"
   ],
   "jest": {
-    "transform": {
-      "^.+\\.ts?$": "ts-jest"
-    },
+    "preset": "ts-jest",
     "testRegex": "test/.*\\.(t|j)sx?$",
     "moduleFileExtensions": [
       "ts",

--- a/src/from-promise.ts
+++ b/src/from-promise.ts
@@ -207,10 +207,10 @@ export namespace fromPromise {
         return p
     })
 
+    function resolveBase<T>(value: T): IFulfilledPromise<T> & IBasePromiseBasedObservable<T>
     function resolveBase<T>(
         value?: T
     ): IFulfilledPromise<T | undefined> & IBasePromiseBasedObservable<T>
-    function resolveBase<T>(value: T): IFulfilledPromise<T> & IBasePromiseBasedObservable<T>
     function resolveBase<T>(
         value: T | undefined = undefined
     ): IFulfilledPromise<T | undefined> & IBasePromiseBasedObservable<T | undefined> {

--- a/test/computedFn.ts
+++ b/test/computedFn.ts
@@ -177,7 +177,7 @@ test("supports options", () => {
 
 test("supports onCleanup", () => {
     const sep = observable.box(".")
-    const unloaded = []
+    const unloaded: unknown[] = []
     const joinedStr = computedFn((sep) => [1, 2, 3].join(sep), {
         onCleanup: (result, sep) => unloaded.push([result, sep]),
     })

--- a/test/create-transformer.ts
+++ b/test/create-transformer.ts
@@ -14,7 +14,7 @@ test("transform1", () => {
     })
 
     let mapped
-    let unloaded = []
+    let unloaded: [{ title: string }, string][] = []
 
     let transformState = createTransformer(function (state: any) {
         stateCalc++
@@ -54,7 +54,7 @@ test("transform1", () => {
     expect(stateCalc).toBe(4)
     expect(todoCalc).toBe(3)
 
-    let tea = state.todos.shift()
+    let tea = state.todos.shift()!
     expect(mapped).toBe("johnBISCUIT")
     expect(stateCalc).toBe(5)
     expect(todoCalc).toBe(3)
@@ -112,6 +112,11 @@ test("createTransformer as off-instance computed", () => {
     // transformer creates a computed but reuses it for every time the same object is passed in
     let displayName = createTransformer(_computeDisplayName)
 
+    interface Person {
+        firstName: string
+        lastName: string
+    }
+
     let person1 = m.observable({
         firstName: "Mickey",
         lastName: "Mouse",
@@ -122,8 +127,8 @@ test("createTransformer as off-instance computed", () => {
         lastName: "Duck",
     })
 
-    let persons = m.observable([])
-    let displayNames = []
+    let persons = m.observable<Person>([])
+    let displayNames: string[] = []
 
     let disposer = m.autorun(() => {
         displayNames = persons.map((p) => displayName(p))
@@ -484,7 +489,7 @@ test("transform tree (modifying tree incrementally)", () => {
     ////////////////////////////////////
 
     // add partial tree as a batch
-    let children = []
+    let children: typeof TreeNode[] = []
     children.push(new TreeNode("root-1-child-1b"))
     children[0].addChild(new TreeNode("root-1-child-1b-child-1"))
     children.push(new TreeNode("root-1-child-2b"))
@@ -1155,8 +1160,8 @@ test("transform with primitive key", () => {
         })
     }
 
-    let observableBobs = m.observable([])
-    let bobs = []
+    let observableBobs = m.observable<string | number>([])
+    let bobs: { name: string }[] = []
 
     let bobFactory = createTransformer(function (key) {
         return new Bob()
@@ -1261,7 +1266,7 @@ function createTestSet(): any {
 
     TreeNode.prototype.path = function () {
         let node = this,
-            parts = []
+            parts: string[] = []
         while (node) {
             parts.push(node.name)
             node = node.parent
@@ -1328,7 +1333,7 @@ test("should respect onCleanup argument", () => {
         name: "michel",
     })
     let mapped
-    let unloaded = []
+    let unloaded: any[] = []
     let objectName
     let transformState = createTransformer(function (state: any) {
         return state.name + state.todos.map(transformTodo).join(",")
@@ -1374,14 +1379,14 @@ test("should respect debugNameGenerator argument", () => {
         mapped = transformTodo(state)
     })
     state.set("name", "BISCUIT")
-    objectName = m.getObserverTree(state, "title").observers[0].name
+    objectName = m.getObserverTree(state, "title").observers?.[0].name
     expect(objectName).toBe("COFFEE-DEBUG")
 })
 
 test("supports computed value options", () => {
     const events: number[][] = []
     const xs = m.observable([1, 2, 3])
-    const xsLessThan = createTransformer((n) => xs.filter((x) => x < n), {
+    const xsLessThan = createTransformer<number, number[]>((n) => xs.filter((x) => x < n), {
         equals: m.comparer.structural,
     })
 

--- a/test/deepObserve.ts
+++ b/test/deepObserve.ts
@@ -76,14 +76,14 @@ test("add", () => {
 })
 
 test("delete", () => {
-    assertChanges({ x: 1 }, (x) => {
+    assertChanges<{ x?: number }>({ x: 1 }, (x) => {
         delete x.x
     })
 })
 
 test("cleanup", () => {
     const a = observable({ b: 1 })
-    const x = observable({ a })
+    const x = observable<{ a?: { b: number } }>({ a })
     const events: any[] = []
 
     const d = deepObserve(x, (change, path) => {

--- a/test/expr.ts
+++ b/test/expr.ts
@@ -22,7 +22,7 @@ test("expr", function () {
             )
         })
 
-        let b = []
+        let b: unknown[] = []
         let sub = mobx.observe(
             total,
             function (x) {
@@ -65,7 +65,7 @@ test("expr2", function () {
             )
         })
 
-        let b = []
+        let b: unknown[] = []
         let sub = mobx.observe(
             total,
             function (x) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "rootDir": ".",
         "lib": ["dom", "es2015", "scripthost"],
         "useDefineForClassFields": true,
+        "strictNullChecks": true,
     },
     "include": ["**/*.ts"],
     "exclude": ["/node_modules"]


### PR DESCRIPTION
# Why is this needed

If you use mobx-utils in a TypeScript project with "strictNullChecks" enabled, you will find that no matter what you pass to `fromPromise.resolve()`, it always returns a type that contains `undefined`:
`IFulfilledPromise<T | undefined> & IBasePromiseBasedObservable<T>;`

This is frustrating because it forces you to check if the value is `undefined` before using it, even though you know it cannot be. The problem can be seen in `test/type-tests.ts` if you turn on "strictNullChecks":

<img width="465" alt="Screen Shot 2022-10-05 at 12 10 17" src="https://user-images.githubusercontent.com/927584/194110545-3165c8a1-d82c-4300-a390-974c374bc62c.png">


# What does this change do

 * Enable "strictNullChecks", and use `preset: "ts-jest"`, to make sure that this TypeScript error is caught by the tests.
 * Re-order the type overloads for `fromPromise.resolve` to fix the failing test.