### PR TITLE
Update computedFn warning to respect mobx global computedRequiresReaction

### DIFF
--- a/src/computedFn.ts
+++ b/src/computedFn.ts
@@ -1,4 +1,3 @@
-import { getGlobalState } from "mobx/dist/internal"
 import { DeepMap } from "./deepMap"
 import {
     IComputedValue,
@@ -7,6 +6,7 @@ import {
     onBecomeUnobserved,
     _isComputingDerivation,
     isAction,
+    _getGlobalState,
 } from "mobx"
 
 export type IComputedFnOptions<F extends (...args: any[]) => any> = {
@@ -53,7 +53,7 @@ export function computedFn<T extends (...args: any[]) => any>(
 ): T {
     if (isAction(fn)) throw new Error("computedFn shouldn't be used on actions")
 
-    let memoWarned = getGlobalState().computedRequiresReaction
+    let memoWarned = false
     let i = 0
     const opts =
         typeof keepAliveOrOptions === "boolean"
@@ -67,7 +67,7 @@ export function computedFn<T extends (...args: any[]) => any>(
         if (entry.exists()) return entry.get().get()
         // if function is invoked, and its a cache miss without reactive, there is no point in caching...
         if (!opts.keepAlive && !_isComputingDerivation()) {
-            if (!memoWarned) {
+            if (!memoWarned && _getGlobalState().computedRequiresReaction) {
                 console.warn(
                     "invoking a computedFn from outside an reactive context won't be memoized, unless keepAlive is set"
                 )

--- a/src/computedFn.ts
+++ b/src/computedFn.ts
@@ -1,3 +1,4 @@
+import { getGlobalState } from "mobx/dist/internal"
 import { DeepMap } from "./deepMap"
 import {
     IComputedValue,
@@ -52,7 +53,7 @@ export function computedFn<T extends (...args: any[]) => any>(
 ): T {
     if (isAction(fn)) throw new Error("computedFn shouldn't be used on actions")
 
-    let memoWarned = false
+    let memoWarned = getGlobalState().computedRequiresReaction
     let i = 0
     const opts =
         typeof keepAliveOrOptions === "boolean"


### PR DESCRIPTION
### Purpose
Addresses this issue: https://github.com/mobxjs/mobx-utils/issues/268

This will allow consumers to test code wrapped with `computedFn` easily by using 
```ts
mobx.configure({ computedRequiresReaction: false })
```


Currently in order to test a computed funciton you either:
1. Ignore the warnings, e.g. `--silent` in jest
2. Wrap the tested function in an `autorun` in each test or during setup before each test.

### Notes
There will be a behavioural change in when a `computedFn` warning is triggered as the default for `computedRequiresReaction` is false. This will make it consistent in behaviour with the base `computed`, but if it is desirable to maintain the existing behavior we could add another option... I'm not sure where that would live, as mobx-utils has no global state and it seems odd to put `computedFnRequiresReaction` within the mobx global state - thoughts?