### PR TITLE
Export `deepObserve`'s `IChange` with more specific name

### DIFF
--- a/src/deepObserve.ts
+++ b/src/deepObserve.ts
@@ -46,8 +46,11 @@ function isRecursivelyObservable(thing: any) {
  *
  * deepObserve cannot be used on computed values.
  *
+ * @param {Object} target The object to observe.
+ * @param {function} listener Invoked when a change is detected.
+ *
  * @example
- * const disposer = deepObserve(target, (change, path) => {
+ * const disposer = deepObserve(target, (change, path, root) => {
  *    console.dir(change)
  * })
  */

--- a/src/deepObserve.ts
+++ b/src/deepObserve.ts
@@ -11,7 +11,7 @@ import {
 } from "mobx"
 import { IDisposer } from "./utils"
 
-type IChange = IObjectDidChange | IArrayDidChange | IMapDidChange
+export type IDeepDidChange = IObjectDidChange | IArrayDidChange | IMapDidChange
 
 type Entry = {
     dispose: IDisposer
@@ -53,17 +53,17 @@ function isRecursivelyObservable(thing: any) {
  */
 export function deepObserve<T = any>(
     target: T,
-    listener: (change: IChange, path: string, root: T) => void
+    listener: (change: IDeepDidChange, path: string, root: T) => void
 ): IDisposer {
     const entrySet = new WeakMap<any, Entry>()
 
-    function genericListener(change: IChange) {
+    function genericListener(change: IDeepDidChange) {
         const entry = entrySet.get(change.object)!
         processChange(change, entry)
         listener(change, buildPath(entry), target)
     }
 
-    function processChange(change: IChange, parent: Entry) {
+    function processChange(change: IDeepDidChange, parent: Entry) {
         switch (change.type) {
             // Object changes
             case "add": // also for map

--- a/test/deepObserve.ts
+++ b/test/deepObserve.ts
@@ -1,8 +1,8 @@
-import { deepObserve } from "../src/mobx-utils"
-import { observable, $mobx, IObjectDidChange } from "mobx"
+import { deepObserve, IDeepDidChange } from "../src/mobx-utils"
+import { observable, $mobx } from "mobx"
 import * as cloneDeepWith from "lodash.clonedeepwith"
 
-function cleanChange(change, includeObject = true) {
+function cleanChange(change: IDeepDidChange, includeObject = true) {
     return cloneDeepWith(change, (value, key) => {
         if (key === $mobx) return null
         if (key === "object" && !includeObject) return null


### PR DESCRIPTION
Adds changes to export the alias of change types supported by `deepObserve` with a slightly less generic name.

Also adds more detail to the relevant doc comments.


## Export 
The alias used by MobX-utils for the `change` parameter of `deepObserve`, previously named `IChange`, is not currently exported.

It only consists of types exported by MobX, though. So, when setting up a listener in an application importing `mobx-utils`, I can define something along these lines to get type information for my listener:

```typescript
export type IDeepDidChange =
  | IObjectDidChange
  | IArrayDidChange
  | IMapDidChange;
```

Nonetheless, the exact set of supported types of changes could of course change in the future (such as once #298 addressed). So, exporting this alias directly from MobX-utils would provide up-to-date type information directly from the package itself.


## Renaming - Rationale

The thinking for renaming `IChange` to `IDeepDidChange` is influenced by: 
- `Deep` - I thought perhaps it would be good to have something not quite as generic as simply 'change' to reflect the fact that this is coming from MobX-utils, and that there are different types of changes are supported in `deepObserve` than in MobX core right now (seen in #298)
- What seems to be an existing convention for 'WillChange' vs 'DidChange'

That said, I'm open to a different name than the one proposed, if there is something that better matches MobX conventions or I'm simply reading too much into the conventions here.

## Documentation

I'm assuming I should just change the JSDoc comment, as it seems the README is auto-generated before a release? Let me know if that is not the case or I need to update the README as well.

Beyond that, I tried also documenting the callback more thoroughly via a separate [JSDoc](https://jsdoc.app/tags-callback.html) block, like so:

```typescript
/**
 * Callback invoked when a deeply observed change is detected.
 *
 * @callback onDeepChange
 * @param {IDeepDidChange} change The type of change
 * @param {string} path The path to the property where the change occurred
 * @param {Object} root The root observed object
 */
```

Which was valid for generation (I tested with `yarn run build-docs`), but the callback was then given the same level of nesting as `deepObserve` (and others) in the README instead of being nested under it (presumably what we'd want). It looks like there is [possibly a way](https://github.com/documentationjs/documentation/blob/master/docs/CONFIG.md#groups) to get documentation to do that, though? Let me know if you see value in pursuing that (also for elsewhere)
