### PR TITLE
Fix a typo in the `computedFn` console warning

### DIFF
--- a/src/computedFn.ts
+++ b/src/computedFn.ts
@@ -69,7 +69,7 @@ export function computedFn<T extends (...args: any[]) => any>(
         if (!opts.keepAlive && !_isComputingDerivation()) {
             if (!memoWarned && _getGlobalState().computedRequiresReaction) {
                 console.warn(
-                    "invoking a computedFn from outside a reactive context won't be memoized unless keepAlive is set" 
+                    "Invoking a computedFn from outside a reactive context won't be memoized unless keepAlive is set." 
                 )
                 memoWarned = true
             }

--- a/src/computedFn.ts
+++ b/src/computedFn.ts
@@ -69,7 +69,7 @@ export function computedFn<T extends (...args: any[]) => any>(
         if (!opts.keepAlive && !_isComputingDerivation()) {
             if (!memoWarned && _getGlobalState().computedRequiresReaction) {
                 console.warn(
-                    "invoking a computedFn from outside an reactive context won't be memoized, unless keepAlive is set"
+                    "invoking a computedFn from outside a reactive context won't be memoized unless keepAlive is set" 
                 )
                 memoWarned = true
             }


### PR DESCRIPTION
This PR fixes a typo (`an reactive context` -> `a reactive context`) in a console warning printed by `computedFn`.