### PR TITLE
Use a Map for createTransformer memoization

### DIFF
--- a/test/create-transformer.ts
+++ b/test/create-transformer.ts
@@ -72,10 +72,10 @@ test("transform1", () => {
           "name": "ObservableObject@1.todos[..].title",
           "observers": Array [
             Object {
-              "name": "Transformer--memoizationId:3",
+              "name": "Transformer--object",
               "observers": Array [
                 Object {
-                  "name": "Transformer--memoizationId:1",
+                  "name": "Transformer--object",
                   "observers": Array [
                     Object {
                       "name": "Autorun@2",


### PR DESCRIPTION
`createTransformer()` memoizes object transformations by creating a key for each possible input of type `A`, and then stores a mapping of that key to an object of type `B` in the context variable `views`. The key is stored on each `A` as a non-enumerable property named `$transformId`, so that each object can be looked up in the `views` cache later.

If we change `views` to be a `Map` instead of a plain object, we can get rid of the need for the IDs completely.

With this new impl, we still treat string and number inputs by value, and we still treat object inputs by identity. This comes down to the hashing semantics of Map.

This saves a small amount of memory in the unique memo IDs that were created for each input, and also some memory on each input object, which was modified to add the `$transformId` property. This may also have a performance benefit, because we aren't modifying the hidden shape of the inputs any more.