### PR TITLE
Fix deepObserve generating a number key for initial array values

### DIFF
--- a/src/deepObserve.ts
+++ b/src/deepObserve.ts
@@ -118,7 +118,7 @@ export function deepObserve<T = any>(
                     dispose: observe(thing, genericListener),
                 }
                 entrySet.set(thing, entry)
-                entries(thing).forEach(([key, value]) => observeRecursively(value, entry, key))
+                entries(thing).forEach(([key, value]) => observeRecursively(value, entry, "" + key))
             }
         }
     }


### PR DESCRIPTION
Initial array values are generating a number key instead of a string key, since entries returns numbers as keys for arrays.