### PR TITLE
Fix memory leak on DeepMap

### DIFF
--- a/src/deepMap.ts
+++ b/src/deepMap.ts
@@ -92,6 +92,11 @@ export class DeepMap<T> {
                 `DeepMap should be used with functions with a consistent length, expected: ${this.argsLength}, got: ${args.length}`
             )
 
+        if (this.currentVersion >= Number.MAX_SAFE_INTEGER) {
+            // Reset version counter when it reaches max safe integer
+            this.currentVersion = 0
+        }
+
         this.currentVersion++
         return new DeepMapEntry(this.store, args, this.currentVersion, this.checkVersion)
     }

--- a/src/deepMap.ts
+++ b/src/deepMap.ts
@@ -81,7 +81,7 @@ export class DeepMap<T> {
     private argsLength = -1
     private currentVersion = 0
 
-    private checkVersion(version: number) {
+    private checkVersion = (version: number) => {
         return this.currentVersion === version
     }
 
@@ -93,6 +93,6 @@ export class DeepMap<T> {
             )
 
         this.currentVersion++
-        return new DeepMapEntry(this.store, args, this.currentVersion, this.checkVersion.bind(this))
+        return new DeepMapEntry(this.store, args, this.currentVersion, this.checkVersion)
     }
 }


### PR DESCRIPTION
Fixes #334

## Memory Leak Fix in DeepMap Implementation

### Issue
The `DeepMap` class in `deepMap.ts` has a memory leak due to maintaining a reference to the last accessed entry. This creates a chain of references that prevents garbage collection:

`computedFn closure -> DeepMap -> this.last -> DeepMapEntry -> args`

### Root Cause
1. The `DeepMap` class maintains a reference to the last accessed entry via `this.last`
2. Even after all entries are deleted, this reference remains
3. This keeps the last `DeepMapEntry` instance alive, which in turn keeps the last arguments alive through its closure
4. The `delete` method only updates internal states within `DeepMapEntry` but doesn't clear the last entry reference