### PR TITLE
Fix: computedFn should call onCleanup when computation is not memoized

### DIFF
--- a/src/computedFn.ts
+++ b/src/computedFn.ts
@@ -69,7 +69,8 @@ export function computedFn<T extends (...args: any[]) => any>(
         if (!opts.keepAlive && !_isComputingDerivation()) {
             if (!memoWarned && _getGlobalState().computedRequiresReaction) {
                 console.warn(
-                    "Invoking a computedFn from outside a reactive context won't be memoized unless keepAlive is set." 
+                    "Invoking a computedFn from outside a reactive context won't be memoized " +
+                        "and is cleaned up immediately, unless keepAlive is set."
                 )
                 memoWarned = true
             }

--- a/src/computedFn.ts
+++ b/src/computedFn.ts
@@ -73,7 +73,9 @@ export function computedFn<T extends (...args: any[]) => any>(
                 )
                 memoWarned = true
             }
-            return fn.apply(this, args)
+            const value = fn.apply(this, args)
+            if (opts.onCleanup) opts.onCleanup(value, ...args)
+            return value
         }
         // create new entry
         let latestValue: ReturnType<T> | undefined


### PR DESCRIPTION
Currently when you invoke `computedFn` outside of a reactive context, the provided `onCleanup` method is never called. This differs from `createTransformer` - https://github.com/mobxjs/mobx-utils/blob/f4d31e8115c208280229843bff0c01924cf8ef97/src/create-transformer.ts#L113