### PR TITLE
Fix: computedFn keeps entries that were only read inside an action

### DIFF
--- a/src/computedFn.ts
+++ b/src/computedFn.ts
@@ -3,6 +3,7 @@ import {
     IComputedValue,
     IComputedValueOptions,
     computed,
+    onBecomeObserved,
     onBecomeUnobserved,
     _isComputingDerivation,
     isAction,
@@ -92,14 +93,31 @@ export function computedFn<T extends (...args: any[]) => any>(
                 name: `computedFn(${opts.name || fn.name}#${++i})`,
             }
         )
-        entry.set(c)
-        // clean up if no longer observed
-        if (!opts.keepAlive)
+        if (opts.keepAlive) {
+            entry.set(c)
+        } else {
+            // Only cache the entry once the `computed` actually becomes observed, that is when
+            // a reaction (or a `keepAlive` `computed`) tracks it. That is also the condition for
+            // `onBecomeUnobserved` to fire later, so every cached entry is evicted again.
+            // Merely being `computed` inside an `action` or an `untracked` scope does not make the
+            // `computed` observed: caching it there would keep the entry and its arguments
+            // alive forever, since nothing would ever evict it.
+            const disposeArm = onBecomeObserved(c, () => {
+                // the entry can already exist if the `computed` went unobserved and observed
+                // again within one batch (the pending eviction is cancelled in that case)
+                const e = d.entry(args)
+                if (!e.exists()) e.set(c)
+            })
+            // clean up if no longer observed
             onBecomeUnobserved(c, () => {
-                d.entry(args).delete()
+                // only evict the entry this computed owns
+                const e = d.entry(args)
+                if (e.exists() && e.get() === c) e.delete()
+                disposeArm()
                 if (opts.onCleanup) opts.onCleanup(latestValue, ...args)
                 latestValue = undefined
             })
+        }
         // return current val
         return c.get()
     } as any

--- a/test/computedFn.ts
+++ b/test/computedFn.ts
@@ -7,6 +7,8 @@ import {
     getDependencyTree,
     comparer,
     getObserverTree,
+    computed,
+    runInAction,
 } from "mobx"
 
 const john = {
@@ -193,4 +195,77 @@ test("supports onCleanup", () => {
 
 test("should not allow actions", () => {
     expect(() => computedFn(action(() => {}))).toThrow("action")
+})
+
+test("does not cache entries that are only read inside an action", () => {
+    const events: string[] = []
+    const unloaded: unknown[] = []
+    const store = observable({ x: 1 })
+    const double = computedFn(
+        (n: number) => {
+            events.push("calc " + n)
+            return store.x * n
+        },
+        { onCleanup: (result, n) => unloaded.push([result, n]) }
+    )
+
+    // A `computed` that is evaluated inside an `action`, without a `reaction` tracking it, never
+    // becomes observed, so its `onBecomeUnobserved` would never fire: nothing may be cached for it.
+    runInAction(() => {
+        expect(computed(() => double(2)).get()).toBe(2)
+    })
+    expect(events).toEqual(["calc 2"])
+    expect(unloaded).toEqual([])
+
+    // The next read outside a derivation takes the uncached path, instead of hitting an entry
+    // that could never be evicted.
+    expect(double(2)).toBe(2)
+    expect(events).toEqual(["calc 2", "calc 2"])
+    expect(unloaded).toEqual([[2, 2]])
+})
+
+test("caches and evicts normally after the same arguments were read inside an action", () => {
+    const events: string[] = []
+    const unloaded: unknown[] = []
+    const store = observable({ x: 1 })
+    const double = computedFn(
+        (n: number) => {
+            events.push("calc " + n)
+            return store.x * n
+        },
+        { onCleanup: (result, n) => unloaded.push([result, n]) }
+    )
+
+    runInAction(() => computed(() => double(2)).get())
+    const d = autorun(() => events.push("autorun " + double(2)))
+    // served from the entry created by the autorun
+    expect(double(2)).toBe(2)
+    runInAction(() => {
+        store.x = 2
+    })
+    d()
+
+    expect(events).toEqual(["calc 2", "calc 2", "autorun 2", "calc 2", "autorun 4"])
+    expect(unloaded).toEqual([[4, 2]])
+})
+
+test("caches nested computedFn calls while observed", () => {
+    const events: string[] = []
+    const store = observable({ x: 1, y: 1 })
+    const inner = computedFn((n: number) => {
+        events.push("inner " + n)
+        return store.x * n
+    })
+    const outer = computedFn((n: number) => {
+        events.push("outer " + n)
+        return inner(n) + store.y
+    })
+
+    const d = autorun(() => events.push("autorun " + outer(2)))
+    runInAction(() => {
+        store.y = 2
+    })
+    d()
+
+    expect(events).toEqual(["outer 2", "inner 2", "autorun 3", "outer 2", "autorun 4"])
 })


### PR DESCRIPTION
Fixes #319.

**Mechanism.** `computedFn` inserts a new `ComputedValue` into its `DeepMap` whenever the call happens inside a derivation (`_isComputingDerivation()`), and relies on `onBecomeUnobserved` to evict it again. MobX only fires `onBecomeUnobserved` for a value that first became observed, and a value only becomes observed when a reaction (or a keepAlive computed) is tracking it. A plain `computed` evaluated inside an action or an untracked scope satisfies `_isComputingDerivation()` but never becomes observed, so the entry it creates has no eviction path: the `ComputedValue`, its closure and its arguments stay in the map for the lifetime of the `computedFn`. `makeAutoObservable` getters read inside actions produce exactly this shape.

**Fix.** Insert the entry from `onBecomeObserved` instead of eagerly at creation. MobX fires that hook synchronously inside the first tracked read, under the same condition that later guarantees `onBecomeUnobserved`, so the map only ever holds entries that can be evicted. This is the public-API form of the `globalState.trackingContext` check suggested in #319: `onBecomeObserved` fires exactly when MobX sets `isBeingObserved` under a tracking context. It also covers MobX 7, where a cached computed that becomes observed later marks its dependencies as observed too (mobxjs/mobx#4547); a creation-time `trackingContext` check would miss that case. Eviction only removes the entry the computed owns and disposes the arming hook. `keepAlive` keeps the eager insertion and no eviction hook, as before.

**Behavior delta.** Repeated reads of the same arguments from a never-observed computed now recompute each time instead of hitting a permanently pinned entry. Across batches this already happened (a suspended `ComputedValue` drops its value), and it matches the documented contract ("memoized as long as the output is being observed"). Reactive reads keep the exact same memoization, untracked reads keep the uncached fast path, and `onCleanup` timing is unchanged.

**Verification.**

- New test `does not cache entries that are only read inside an action` fails on master and passes with the fix. Two more tests cover caching and eviction after such a read, and nested `computedFn` calls under one reaction. Full suite green on mobx 6.0.0 (the locked dev dependency).
- Retention, measured with `node --expose-gc` and `v8.queryObjects` against the built UMD before and after, for 10,000 distinct argument objects each read once through a `computed` inside an action:

  |          | ComputedValues retained | keys retained | heap                          |
  | -------- | ----------------------- | ------------- | ----------------------------- |
  | master   | 10,000                  | 10,000        | +12.3 MB (~1.3 KB per entry)  |
  | this PR  | 0                       | 0             | +0.0 MB                       |

  Values are identical on both. Same result on mobx 7.0.3, where the three new tests pass as well (run transpile-only, since the existing suite predates mobx 7's API changes). The same harness also checks reactive memoization counts, cross-reaction cache hits, invalidation, the untracked fast path, keepAlive, a reaction picking up arguments that were first read inside an action, and nested layers; all identical between master and this PR.
